### PR TITLE
Update codegen arguments to use new output templating.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,7 +93,7 @@ fun generateTask(taskName: String, incubating: Boolean) {
         "otel/semconvgen:$generatorVersion",
         "--yaml-root", "/source", "code",
         "--template", "/templates/SemanticAttributes.java.j2",
-        "--output", "/output/${classPrefix}Attributes.java",
+        "--output", "/output/{{pascal_prefix}}${classPrefix}Attributes.java",
         "--file-per-group", "root_namespace",
         "-Dfilter=${filter}",
         "-DclassPrefix=${classPrefix}",


### PR DESCRIPTION
We updated the output argument to be a template that can leverage different file name prefix options.

See: https://github.com/open-telemetry/build-tools/pull/263