### PR TITLE
Add semconv classes from 1.23.1 for compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,9 +11,10 @@ val snapshot = true
 // end
 
 // The release version of https://github.com/open-telemetry/semantic-conventions used to generate classes
-var semanticConventionsVersion = "1.24.0"
+var semanticConventionsVersion = "eccdb311ff468b2379469551f5998014de2c8491"
 val schemaUrlVersions = listOf(
-    semanticConventionsVersion,
+    "1.25.0",
+    "1.24.0",
     "1.23.1",
     "1.22.0")
 
@@ -52,7 +53,7 @@ nexusPublishing {
 
 // start - define tasks to download, unzip, and generate from opentelemetry/semantic-conventions
 var generatorVersion = "0.24.0"
-val semanticConventionsRepoZip = "https://github.com/open-telemetry/semantic-conventions/archive/v$semanticConventionsVersion.zip"
+val semanticConventionsRepoZip = "https://github.com/lmolkova/semantic-conventions/archive/${semanticConventionsVersion}.zip"
 val schemaUrl = "https://opentelemetry.io/schemas/$semanticConventionsVersion"
 
 val downloadSemanticConventions by tasks.registering(Download::class) {

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/AwsIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/AwsIncubatingAttributes.java
@@ -43,7 +43,7 @@ public final class AwsIncubatingAttributes {
       stringKey("aws.dynamodb.exclusive_start_table");
 
   /**
-   * The JSON-serialized value of each item in the the {@code GlobalSecondaryIndexUpdates} request
+   * The JSON-serialized value of each item in the {@code GlobalSecondaryIndexUpdates} request
    * field.
    */
   public static final AttributeKey<List<String>> AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES =
@@ -94,7 +94,7 @@ public final class AwsIncubatingAttributes {
   /** The value of the {@code Select} request parameter. */
   public static final AttributeKey<String> AWS_DYNAMODB_SELECT = stringKey("aws.dynamodb.select");
 
-  /** The the number of items in the {@code TableNames} response parameter. */
+  /** The number of items in the {@code TableNames} response parameter. */
   public static final AttributeKey<Long> AWS_DYNAMODB_TABLE_COUNT =
       longKey("aws.dynamodb.table_count");
 
@@ -129,16 +129,23 @@ public final class AwsIncubatingAttributes {
   public static final AttributeKey<String> AWS_ECS_LAUNCHTYPE = stringKey("aws.ecs.launchtype");
 
   /**
-   * The ARN of an <a
-   * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html">ECS
-   * task definition</a>.
+   * The ARN of a running <a
+   * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids">ECS
+   * task</a>.
    */
   public static final AttributeKey<String> AWS_ECS_TASK_ARN = stringKey("aws.ecs.task.arn");
 
-  /** The task definition family this task definition is a member of. */
+  /**
+   * The family name of the <a
+   * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html">ECS
+   * task definition</a> used to create the ECS task.
+   */
   public static final AttributeKey<String> AWS_ECS_TASK_FAMILY = stringKey("aws.ecs.task.family");
 
-  /** The revision for this task definition. */
+  /** The ID of a running ECS task. The ID MUST be extracted from {@code task.arn}. */
+  public static final AttributeKey<String> AWS_ECS_TASK_ID = stringKey("aws.ecs.task.id");
+
+  /** The revision for the task definition used to create the ECS task. */
   public static final AttributeKey<String> AWS_ECS_TASK_REVISION =
       stringKey("aws.ecs.task.revision");
 

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/CloudIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/CloudIncubatingAttributes.java
@@ -131,6 +131,9 @@ public final class CloudIncubatingAttributes {
     /** Azure Virtual Machines. */
     public static final String AZURE_VM = "azure_vm";
 
+    /** Azure Container Apps. */
+    public static final String AZURE_CONTAINER_APPS = "azure_container_apps";
+
     /** Azure Container Instances. */
     public static final String AZURE_CONTAINER_INSTANCES = "azure_container_instances";
 

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ContainerIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ContainerIncubatingAttributes.java
@@ -40,6 +40,9 @@ public final class ContainerIncubatingAttributes {
   public static final AttributeKey<String> CONTAINER_COMMAND_LINE =
       stringKey("container.command_line");
 
+  /** The CPU state for this data point. */
+  public static final AttributeKey<String> CONTAINER_CPU_STATE = stringKey("container.cpu.state");
+
   /**
    * Container ID. Usually a UUID, as for example used to <a
    * href="https://docs.docker.com/engine/reference/run/#container-identification">identify Docker
@@ -95,6 +98,15 @@ public final class ContainerIncubatingAttributes {
       stringArrayKey("container.image.tags");
 
   /** Container labels, {@code <key>} being the label name, the value being the label value. */
+  public static final AttributeKeyTemplate<String> CONTAINER_LABEL =
+      stringKeyTemplate("container.label");
+
+  /**
+   * Deprecated, use {@code container.label} instead.
+   *
+   * @deprecated Deprecated, use `container.label` instead.
+   */
+  @Deprecated
   public static final AttributeKeyTemplate<String> CONTAINER_LABELS =
       stringKeyTemplate("container.labels");
 
@@ -103,6 +115,27 @@ public final class ContainerIncubatingAttributes {
 
   /** The container runtime managing this container. */
   public static final AttributeKey<String> CONTAINER_RUNTIME = stringKey("container.runtime");
+
+  // Enum definitions
+  /** Values for {@link #CONTAINER_CPU_STATE}. */
+  public static final class ContainerCpuStateValues {
+    /**
+     * When tasks of the cgroup are in user mode (Linux). When all container processes are in user
+     * mode (Windows).
+     */
+    public static final String USER = "user";
+
+    /** When CPU is used by the system (host OS). */
+    public static final String SYSTEM = "system";
+
+    /**
+     * When tasks of the cgroup are in kernel mode (Linux). When all container processes are in
+     * kernel mode (Windows).
+     */
+    public static final String KERNEL = "kernel";
+
+    private ContainerCpuStateValues() {}
+  }
 
   private ContainerIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DbIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DbIncubatingAttributes.java
@@ -65,9 +65,11 @@ public final class DbIncubatingAttributes {
   public static final AttributeKey<String> DB_CASSANDRA_TABLE = stringKey("db.cassandra.table");
 
   /**
-   * The connection string used to connect to the database. It is recommended to remove embedded
-   * credentials.
+   * Deprecated, use {@code server.address}, {@code server.port} attributes instead.
+   *
+   * @deprecated Deprecated, use `server.address`, `server.port` attributes instead.
    */
+  @Deprecated
   public static final AttributeKey<String> DB_CONNECTION_STRING = stringKey("db.connection_string");
 
   /** Unique Cosmos client instance id. */
@@ -107,8 +109,11 @@ public final class DbIncubatingAttributes {
       stringKey("db.elasticsearch.cluster.name");
 
   /**
-   * Represents the human-readable identifier of the node/instance to which a request was routed.
+   * Deprecated, use {@code db.instance.id} instead.
+   *
+   * @deprecated Deprecated, use `db.instance.id` instead.
    */
+  @Deprecated
   public static final AttributeKey<String> DB_ELASTICSEARCH_NODE_NAME =
       stringKey("db.elasticsearch.node.name");
 
@@ -138,10 +143,11 @@ public final class DbIncubatingAttributes {
   public static final AttributeKey<String> DB_INSTANCE_ID = stringKey("db.instance.id");
 
   /**
-   * The fully-qualified class name of the <a
-   * href="https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/">Java Database Connectivity
-   * (JDBC)</a> driver used to connect.
+   * Removed, no replacement at this time.
+   *
+   * @deprecated Removed, no replacement at this time.
    */
+  @Deprecated
   public static final AttributeKey<String> DB_JDBC_DRIVER_CLASSNAME =
       stringKey("db.jdbc.driver_classname");
 

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DnsIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DnsIncubatingAttributes.java
@@ -20,10 +20,10 @@ public final class DnsIncubatingAttributes {
    * <p>Notes:
    *
    * <ul>
-   *   <li>The name being queried. If the name field contains non-printable characters (below 32 or
-   *       above 126), those characters should be represented as escaped base 10 integers (\DDD).
-   *       Back slashes and quotes should be escaped. Tabs, carriage returns, and line feeds should
-   *       be converted to \t, \r, and \n respectively.
+   *   <li>If the name field contains non-printable characters (below 32 or above 126), those
+   *       characters should be represented as escaped base 10 integers (\DDD). Back slashes and
+   *       quotes should be escaped. Tabs, carriage returns, and line feeds should be converted to
+   *       \t, \r, and \n respectively.
    * </ul>
    */
   public static final AttributeKey<String> DNS_QUESTION_NAME = stringKey("dns.question.name");

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/EventIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/EventIncubatingAttributes.java
@@ -21,7 +21,7 @@ public final class EventIncubatingAttributes {
    *
    * <ul>
    *   <li>Event names are subject to the same rules as <a
-   *       href="https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/common/attribute-naming.md">attribute
+   *       href="https://github.com/open-telemetry/opentelemetry-specification/tree/v1.31.0/specification/common/attribute-naming.md">attribute
    *       names</a>. Notably, event names are namespaced to avoid collisions and provide a clean
    *       separation of semantics for events in separate domains like browser, mobile, and
    *       kubernetes.

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/FileIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/FileIncubatingAttributes.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.semconv.incubating;
+
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+// DO NOT EDIT, this is an Auto-generated file from
+// buildscripts/templates/SemanticAttributes.java.j2
+@SuppressWarnings("unused")
+public final class FileIncubatingAttributes {
+
+  /** Directory where the file is located. It should include the drive letter, when appropriate. */
+  public static final AttributeKey<String> FILE_DIRECTORY = stringKey("file.directory");
+
+  /**
+   * File extension, excluding the leading dot.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>When the file name has multiple extensions (example.tar.gz), only the last one should be
+   *       captured (&quot;gz&quot;, not &quot;tar.gz&quot;).
+   * </ul>
+   */
+  public static final AttributeKey<String> FILE_EXTENSION = stringKey("file.extension");
+
+  /** Name of the file including the extension, without the directory. */
+  public static final AttributeKey<String> FILE_NAME = stringKey("file.name");
+
+  /**
+   * Full path to the file, including the file name. It should include the drive letter, when
+   * appropriate.
+   */
+  public static final AttributeKey<String> FILE_PATH = stringKey("file.path");
+
+  /** File size in bytes. */
+  public static final AttributeKey<Long> FILE_SIZE = longKey("file.size");
+
+  private FileIncubatingAttributes() {}
+}

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/HostIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/HostIncubatingAttributes.java
@@ -36,7 +36,7 @@ public final class HostIncubatingAttributes {
   public static final AttributeKey<String> HOST_CPU_MODEL_NAME = stringKey("host.cpu.model.name");
 
   /** Stepping or core revisions. */
-  public static final AttributeKey<Long> HOST_CPU_STEPPING = longKey("host.cpu.stepping");
+  public static final AttributeKey<String> HOST_CPU_STEPPING = stringKey("host.cpu.stepping");
 
   /**
    * Processor manufacturer identifier. A maximum 12-character string.

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/HttpIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/HttpIncubatingAttributes.java
@@ -128,6 +128,13 @@ public final class HttpIncubatingAttributes {
       longKey("http.request.resend_count");
 
   /**
+   * The total size of the request in bytes. This should be the total number of bytes sent over the
+   * wire, including the request line (HTTP/1.1), framing (HTTP/2 and HTTP/3), headers, and request
+   * body if any.
+   */
+  public static final AttributeKey<Long> HTTP_REQUEST_SIZE = longKey("http.request.size");
+
+  /**
    * Deprecated, use {@code http.request.header.content-length} instead.
    *
    * @deprecated Deprecated, use `http.request.header.content-length` instead.
@@ -167,6 +174,13 @@ public final class HttpIncubatingAttributes {
   @Deprecated
   public static final AttributeKeyTemplate<List<String>> HTTP_RESPONSE_HEADER =
       stringArrayKeyTemplate("http.response.header");
+
+  /**
+   * The total size of the response in bytes. This should be the total number of bytes sent over the
+   * wire, including the status line (HTTP/1.1), framing (HTTP/2 and HTTP/3), headers, and response
+   * body and trailers if any.
+   */
+  public static final AttributeKey<Long> HTTP_RESPONSE_SIZE = longKey("http.response.size");
 
   /**
    * <a href="https://tools.ietf.org/html/rfc7231#section-6">HTTP response status code</a>.

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/K8sIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/K8sIncubatingAttributes.java
@@ -99,9 +99,18 @@ public final class K8sIncubatingAttributes {
       stringKeyTemplate("k8s.pod.annotation");
 
   /**
-   * The labels placed on the Pod, the {@code <key>} being the label name, the value being the label
-   * value.
+   * The label key-value pairs placed on the Pod, the {@code <key>} being the label name, the value
+   * being the label value.
    */
+  public static final AttributeKeyTemplate<String> K8S_POD_LABEL =
+      stringKeyTemplate("k8s.pod.label");
+
+  /**
+   * Deprecated, use {@code k8s.pod.label} instead.
+   *
+   * @deprecated Deprecated, use `k8s.pod.label` instead.
+   */
+  @Deprecated
   public static final AttributeKeyTemplate<String> K8S_POD_LABELS =
       stringKeyTemplate("k8s.pod.labels");
 

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/MessagingIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/MessagingIncubatingAttributes.java
@@ -59,6 +59,13 @@ public final class MessagingIncubatingAttributes {
       stringKey("messaging.destination.name");
 
   /**
+   * The identifier of the partition messages are sent to or received from, unique within the {@code
+   * messaging.destination.name}.
+   */
+  public static final AttributeKey<String> MESSAGING_DESTINATION_PARTITION_ID =
+      stringKey("messaging.destination.partition.id");
+
+  /**
    * Low cardinality representation of the messaging destination name
    *
    * <p>Notes:
@@ -101,6 +108,14 @@ public final class MessagingIncubatingAttributes {
   public static final AttributeKey<String> MESSAGING_DESTINATION_PUBLISH_NAME =
       stringKey("messaging.destination_publish.name");
 
+  /** The name of the consumer group the event consumer is associated with. */
+  public static final AttributeKey<String> MESSAGING_EVENTHUBS_CONSUMER_GROUP =
+      stringKey("messaging.eventhubs.consumer.group");
+
+  /** The UTC epoch seconds at which the message has been accepted and stored in the entity. */
+  public static final AttributeKey<Long> MESSAGING_EVENTHUBS_MESSAGE_ENQUEUED_TIME =
+      longKey("messaging.eventhubs.message.enqueued_time");
+
   /**
    * The ordering key for a given message. If the attribute is not present, the message does not
    * have an ordering key.
@@ -115,7 +130,12 @@ public final class MessagingIncubatingAttributes {
   public static final AttributeKey<String> MESSAGING_KAFKA_CONSUMER_GROUP =
       stringKey("messaging.kafka.consumer.group");
 
-  /** Partition the message is sent to. */
+  /**
+   * &quot;Deprecated, use {@code messaging.destination.partition.id} instead.&quot;
+   *
+   * @deprecated "Deprecated, use `messaging.destination.partition.id` instead.".
+   */
+  @Deprecated
   public static final AttributeKey<Long> MESSAGING_KAFKA_DESTINATION_PARTITION =
       longKey("messaging.kafka.destination.partition");
 
@@ -195,6 +215,10 @@ public final class MessagingIncubatingAttributes {
   public static final AttributeKey<String> MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY =
       stringKey("messaging.rabbitmq.destination.routing_key");
 
+  /** RabbitMQ message delivery tag */
+  public static final AttributeKey<Long> MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG =
+      longKey("messaging.rabbitmq.message.delivery_tag");
+
   /**
    * Name of the RocketMQ producer/consumer group that is handling the message. The client type is
    * identified by the SpanKind.
@@ -239,6 +263,26 @@ public final class MessagingIncubatingAttributes {
   public static final AttributeKey<String> MESSAGING_ROCKETMQ_NAMESPACE =
       stringKey("messaging.rocketmq.namespace");
 
+  /** The name of the subscription in the topic messages are received from. */
+  public static final AttributeKey<String> MESSAGING_SERVICEBUS_DESTINATION_SUBSCRIPTION_NAME =
+      stringKey("messaging.servicebus.destination.subscription_name");
+
+  /**
+   * Describes the <a
+   * href="https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock">settlement
+   * type</a>.
+   */
+  public static final AttributeKey<String> MESSAGING_SERVICEBUS_DISPOSITION_STATUS =
+      stringKey("messaging.servicebus.disposition_status");
+
+  /** Number of deliveries that have been attempted for this message. */
+  public static final AttributeKey<Long> MESSAGING_SERVICEBUS_MESSAGE_DELIVERY_COUNT =
+      longKey("messaging.servicebus.message.delivery_count");
+
+  /** The UTC epoch seconds at which the message has been accepted and stored in the entity. */
+  public static final AttributeKey<Long> MESSAGING_SERVICEBUS_MESSAGE_ENQUEUED_TIME =
+      longKey("messaging.servicebus.message.enqueued_time");
+
   /**
    * An identifier for the messaging system being used. See below for a list of well-known
    * identifiers.
@@ -267,11 +311,11 @@ public final class MessagingIncubatingAttributes {
      */
     public static final String RECEIVE = "receive";
 
-    /**
-     * One or more messages are passed to a consumer. This operation refers to push-based scenarios,
-     * where consumer register callbacks which get called by messaging SDKs.
-     */
-    public static final String DELIVER = "deliver";
+    /** One or more messages are delivered to or processed by a consumer. */
+    public static final String DELIVER = "process";
+
+    /** One or more messages are settled. */
+    public static final String SETTLE = "settle";
 
     private MessagingOperationValues() {}
   }
@@ -304,6 +348,23 @@ public final class MessagingIncubatingAttributes {
     private MessagingRocketmqMessageTypeValues() {}
   }
 
+  /** Values for {@link #MESSAGING_SERVICEBUS_DISPOSITION_STATUS}. */
+  public static final class MessagingServicebusDispositionStatusValues {
+    /** Message is completed. */
+    public static final String COMPLETE = "complete";
+
+    /** Message is abandoned. */
+    public static final String ABANDON = "abandon";
+
+    /** Message is sent to dead letter queue. */
+    public static final String DEAD_LETTER = "dead_letter";
+
+    /** Message is deferred. */
+    public static final String DEFER = "defer";
+
+    private MessagingServicebusDispositionStatusValues() {}
+  }
+
   /** Values for {@link #MESSAGING_SYSTEM}. */
   public static final class MessagingSystemValues {
     /** Apache ActiveMQ. */
@@ -313,13 +374,13 @@ public final class MessagingIncubatingAttributes {
     public static final String AWS_SQS = "aws_sqs";
 
     /** Azure Event Grid. */
-    public static final String AZURE_EVENTGRID = "azure_eventgrid";
+    public static final String EVENTGRID = "eventgrid";
 
     /** Azure Event Hubs. */
-    public static final String AZURE_EVENTHUBS = "azure_eventhubs";
+    public static final String EVENTHUBS = "eventhubs";
 
     /** Azure Service Bus. */
-    public static final String AZURE_SERVICEBUS = "azure_servicebus";
+    public static final String SERVICEBUS = "servicebus";
 
     /** Google Cloud Pub/Sub. */
     public static final String GCP_PUBSUB = "gcp_pubsub";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/NetworkIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/NetworkIncubatingAttributes.java
@@ -96,14 +96,15 @@ public final class NetworkIncubatingAttributes {
       stringKey("network.protocol.name");
 
   /**
-   * Version of the protocol specified in {@code network.protocol.name}.
+   * The actual version of the protocol used for network communication.
    *
    * <p>Notes:
    *
    * <ul>
-   *   <li>{@code network.protocol.version} refers to the version of the protocol used and might be
-   *       different from the protocol client's version. If the HTTP client has a version of {@code
-   *       0.27.2}, but sends HTTP version {@code 1.1}, this attribute should be set to {@code 1.1}.
+   *   <li>If protocol version is subject to negotiation (for example using <a
+   *       href="https://www.rfc-editor.org/rfc/rfc7301.html">ALPN</a>), this attribute SHOULD be
+   *       set to the negotiated version. If the actual protocol version is not known, this
+   *       attribute SHOULD NOT be set.
    * </ul>
    *
    * @deprecated deprecated in favor of stable {@link

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/OtelIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/OtelIncubatingAttributes.java
@@ -14,30 +14,68 @@ import io.opentelemetry.api.common.AttributeKey;
 @SuppressWarnings("unused")
 public final class OtelIncubatingAttributes {
 
-  /** Deprecated, use the {@code otel.scope.name} attribute. */
+  /**
+   * None
+   *
+   * @deprecated None.
+   */
+  @Deprecated
   public static final AttributeKey<String> OTEL_LIBRARY_NAME = stringKey("otel.library.name");
 
-  /** Deprecated, use the {@code otel.scope.version} attribute. */
+  /**
+   * None
+   *
+   * @deprecated None.
+   */
+  @Deprecated
   public static final AttributeKey<String> OTEL_LIBRARY_VERSION = stringKey("otel.library.version");
 
-  /** The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP). */
+  /**
+   * The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP).
+   *
+   * @deprecated deprecated in favor of stable {@link
+   *     io.opentelemetry.semconv.OtelAttributes#OTEL_SCOPE_NAME} attribute.
+   */
+  @Deprecated
   public static final AttributeKey<String> OTEL_SCOPE_NAME = stringKey("otel.scope.name");
 
-  /** The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP). */
+  /**
+   * The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP).
+   *
+   * @deprecated deprecated in favor of stable {@link
+   *     io.opentelemetry.semconv.OtelAttributes#OTEL_SCOPE_VERSION} attribute.
+   */
+  @Deprecated
   public static final AttributeKey<String> OTEL_SCOPE_VERSION = stringKey("otel.scope.version");
 
   /**
    * Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set if the status
    * code is UNSET.
+   *
+   * @deprecated deprecated in favor of stable {@link
+   *     io.opentelemetry.semconv.OtelAttributes#OTEL_STATUS_CODE} attribute.
    */
+  @Deprecated
   public static final AttributeKey<String> OTEL_STATUS_CODE = stringKey("otel.status_code");
 
-  /** Description of the Status if it has a value, otherwise not set. */
+  /**
+   * Description of the Status if it has a value, otherwise not set.
+   *
+   * @deprecated deprecated in favor of stable {@link
+   *     io.opentelemetry.semconv.OtelAttributes#OTEL_STATUS_DESCRIPTION} attribute.
+   */
+  @Deprecated
   public static final AttributeKey<String> OTEL_STATUS_DESCRIPTION =
       stringKey("otel.status_description");
 
   // Enum definitions
-  /** Values for {@link #OTEL_STATUS_CODE}. */
+  /**
+   * Values for {@link #OTEL_STATUS_CODE}.
+   *
+   * @deprecated deprecated in favor of stable {@link
+   *     io.opentelemetry.semconv.OtelAttributes.OtelStatusCodeValues} attribute.
+   */
+  @Deprecated
   public static final class OtelStatusCodeValues {
     /**
      * The operation has been validated by an Application developer or Operator to have completed

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/PoolIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/PoolIncubatingAttributes.java
@@ -16,9 +16,9 @@ public final class PoolIncubatingAttributes {
 
   /**
    * The name of the connection pool; unique within the instrumented application. In case the
-   * connection pool implementation doesn't provide a name, then the <a
-   * href="/docs/database/database-spans.md#connection-level-attributes">db.connection_string</a>
-   * should be used
+   * connection pool implementation doesn't provide a name, instrumentation should use a combination
+   * of {@code server.address} and {@code server.port} attributes formatted as {@code
+   * server.address:server.port}.
    */
   public static final AttributeKey<String> POOL_NAME = stringKey("pool.name");
 

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ProcessIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ProcessIncubatingAttributes.java
@@ -40,6 +40,16 @@ public final class ProcessIncubatingAttributes {
    */
   public static final AttributeKey<String> PROCESS_COMMAND_LINE = stringKey("process.command_line");
 
+  /** Specifies whether the context switches for this data point were voluntary or involuntary. */
+  public static final AttributeKey<String> PROCESS_CONTEXT_SWITCH_TYPE =
+      stringKey("process.context_switch_type");
+
+  /**
+   * The CPU state for this data point. A process SHOULD be characterized <em>either</em> by data
+   * points with no {@code state} labels, <em>or only</em> data points with {@code state} labels.
+   */
+  public static final AttributeKey<String> PROCESS_CPU_STATE = stringKey("process.cpu.state");
+
   /**
    * The name of the process executable. On Linux based systems, can be set to the {@code Name} in
    * {@code proc/[pid]/status}. On Windows, can be set to the base name of {@code
@@ -58,6 +68,13 @@ public final class ProcessIncubatingAttributes {
 
   /** The username of the user that owns the process. */
   public static final AttributeKey<String> PROCESS_OWNER = stringKey("process.owner");
+
+  /**
+   * The type of page fault for this data point. Type {@code major} is for major/hard page faults,
+   * and {@code minor} is for minor/soft page faults.
+   */
+  public static final AttributeKey<String> PROCESS_PAGING_FAULT_TYPE =
+      stringKey("process.paging.fault_type");
 
   /** Parent Process identifier (PPID). */
   public static final AttributeKey<Long> PROCESS_PARENT_PID = longKey("process.parent_pid");
@@ -83,6 +100,43 @@ public final class ProcessIncubatingAttributes {
    */
   public static final AttributeKey<String> PROCESS_RUNTIME_VERSION =
       stringKey("process.runtime.version");
+
+  // Enum definitions
+  /** Values for {@link #PROCESS_CONTEXT_SWITCH_TYPE}. */
+  public static final class ProcessContextSwitchTypeValues {
+    /** voluntary. */
+    public static final String VOLUNTARY = "voluntary";
+
+    /** involuntary. */
+    public static final String INVOLUNTARY = "involuntary";
+
+    private ProcessContextSwitchTypeValues() {}
+  }
+
+  /** Values for {@link #PROCESS_CPU_STATE}. */
+  public static final class ProcessCpuStateValues {
+    /** system. */
+    public static final String SYSTEM = "system";
+
+    /** user. */
+    public static final String USER = "user";
+
+    /** wait. */
+    public static final String WAIT = "wait";
+
+    private ProcessCpuStateValues() {}
+  }
+
+  /** Values for {@link #PROCESS_PAGING_FAULT_TYPE}. */
+  public static final class ProcessPagingFaultTypeValues {
+    /** major. */
+    public static final String MAJOR = "major";
+
+    /** minor. */
+    public static final String MINOR = "minor";
+
+    private ProcessPagingFaultTypeValues() {}
+  }
 
   private ProcessIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ServiceIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ServiceIncubatingAttributes.java
@@ -23,13 +23,28 @@ public final class ServiceIncubatingAttributes {
    *   <li>MUST be unique for each instance of the same {@code service.namespace,service.name} pair
    *       (in other words {@code service.namespace,service.name,service.instance.id} triplet MUST
    *       be globally unique). The ID helps to distinguish instances of the same service that exist
-   *       at the same time (e.g. instances of a horizontally scaled service). It is preferable for
-   *       the ID to be persistent and stay the same for the lifetime of the service instance,
-   *       however it is acceptable that the ID is ephemeral and changes during important lifetime
-   *       events for the service (e.g. service restarts). If the service has no inherent unique ID
-   *       that can be used as the value of this attribute it is recommended to generate a random
-   *       Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use
-   *       Version 5, see RFC 4122 for more recommendations).
+   *       at the same time (e.g. instances of a horizontally scaled service).
+   *   <li>Implementations, such as SDKs, are recommended to generate a random Version 1 or Version
+   *       4 <a href="https://www.ietf.org/rfc/rfc4122.txt">RFC 4122</a> UUID, but are free to use
+   *       an inherent unique ID as the source of this value if stability is desirable. In that
+   *       case, the ID SHOULD be used as source of a UUID Version 5 and SHOULD use the following
+   *       UUID as the namespace: {@code 4d63009a-8d0f-11ee-aad7-4c796ed8e320}.
+   *   <li>UUIDs are typically recommended, as only an opaque value for the purposes of identifying
+   *       a service instance is needed. Similar to what can be seen in the man page for the <a
+   *       href="https://www.freedesktop.org/software/systemd/man/machine-id.html">{@code
+   *       /etc/machine-id}</a> file, the underlying data, such as pod name and namespace should be
+   *       treated as confidential, being the user's choice to expose it or not via another resource
+   *       attribute.
+   *   <li>For applications running behind an application server (like unicorn), we do not recommend
+   *       using one identifier for all processes participating in the application. Instead, it's
+   *       recommended each division (e.g. a worker thread in unicorn) to have its own instance.id.
+   *   <li>It's not recommended for a Collector to set {@code service.instance.id} if it can't
+   *       unambiguously determine the service instance that is generating that telemetry. For
+   *       instance, creating an UUID based on {@code pod.name} will likely be wrong, as the
+   *       Collector might not know from which container within that pod the telemetry originated.
+   *       However, Collectors can set the {@code service.instance.id} if they can unambiguously
+   *       determine the service instance for that telemetry. This is typically the case for
+   *       scraping receivers, as they know the target address and port.
    * </ul>
    */
   public static final AttributeKey<String> SERVICE_INSTANCE_ID = stringKey("service.instance.id");
@@ -46,8 +61,11 @@ public final class ServiceIncubatingAttributes {
    *       unknown_service:bash}. If {@code process.executable.name} is not available, the value
    *       MUST be set to {@code unknown_service}.
    * </ul>
+   *
+   * @deprecated deprecated in favor of stable {@link
+   *     io.opentelemetry.semconv.ServiceAttributes#SERVICE_NAME} attribute.
    */
-  public static final AttributeKey<String> SERVICE_NAME = stringKey("service.name");
+  @Deprecated public static final AttributeKey<String> SERVICE_NAME = stringKey("service.name");
 
   /**
    * A namespace for {@code service.name}.
@@ -68,7 +86,11 @@ public final class ServiceIncubatingAttributes {
   /**
    * The version string of the service API or implementation. The format is not defined by these
    * conventions.
+   *
+   * @deprecated deprecated in favor of stable {@link
+   *     io.opentelemetry.semconv.ServiceAttributes#SERVICE_VERSION} attribute.
    */
+  @Deprecated
   public static final AttributeKey<String> SERVICE_VERSION = stringKey("service.version");
 
   private ServiceIncubatingAttributes() {}

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/SystemIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/SystemIncubatingAttributes.java
@@ -19,7 +19,11 @@ public final class SystemIncubatingAttributes {
   public static final AttributeKey<Long> SYSTEM_CPU_LOGICAL_NUMBER =
       longKey("system.cpu.logical_number");
 
-  /** The state of the CPU */
+  /**
+   * The CPU state for this data point. A system's CPU SHOULD be characterized <em>either</em> by
+   * data points with no {@code state} labels, <em>or only</em> data points with {@code state}
+   * labels.
+   */
   public static final AttributeKey<String> SYSTEM_CPU_STATE = stringKey("system.cpu.state");
 
   /** The device identifier */
@@ -62,6 +66,15 @@ public final class SystemIncubatingAttributes {
    * href="https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES">Linux Process State
    * Codes</a>
    */
+  public static final AttributeKey<String> SYSTEM_PROCESS_STATUS =
+      stringKey("system.process.status");
+
+  /**
+   * Deprecated, use {@code system.process.status} instead.
+   *
+   * @deprecated Deprecated, use `system.process.status` instead.
+   */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_PROCESSES_STATUS =
       stringKey("system.processes.status");
 
@@ -223,7 +236,29 @@ public final class SystemIncubatingAttributes {
     private SystemPagingTypeValues() {}
   }
 
-  /** Values for {@link #SYSTEM_PROCESSES_STATUS}. */
+  /** Values for {@link #SYSTEM_PROCESS_STATUS}. */
+  public static final class SystemProcessStatusValues {
+    /** running. */
+    public static final String RUNNING = "running";
+
+    /** sleeping. */
+    public static final String SLEEPING = "sleeping";
+
+    /** stopped. */
+    public static final String STOPPED = "stopped";
+
+    /** defunct. */
+    public static final String DEFUNCT = "defunct";
+
+    private SystemProcessStatusValues() {}
+  }
+
+  /**
+   * Values for {@link #SYSTEM_PROCESSES_STATUS}.
+   *
+   * @deprecated Deprecated, use `system.process.status` instead.
+   */
+  @Deprecated
   public static final class SystemProcessesStatusValues {
     /** running. */
     public static final String RUNNING = "running";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/UrlIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/UrlIncubatingAttributes.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.semconv.incubating;
 
+import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -13,6 +14,34 @@ import io.opentelemetry.api.common.AttributeKey;
 // buildscripts/templates/SemanticAttributes.java.j2
 @SuppressWarnings("unused")
 public final class UrlIncubatingAttributes {
+
+  /**
+   * Domain extracted from the {@code url.full}, such as &quot;opentelemetry.io&quot;.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>In some cases a URL may refer to an IP and/or port directly, without a domain name. In
+   *       this case, the IP address would go to the domain field. If the URL contains a <a
+   *       href="https://www.rfc-editor.org/rfc/rfc2732#section-2">literal IPv6 address</a> enclosed
+   *       by {@code [} and {@code ]}, the {@code [} and {@code ]} characters should also be
+   *       captured in the domain field.
+   * </ul>
+   */
+  public static final AttributeKey<String> URL_DOMAIN = stringKey("url.domain");
+
+  /**
+   * The file extension extracted from the {@code url.full}, excluding the leading dot.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The file extension is only set if it exists, as not every url has a file extension. When
+   *       the file name has multiple extensions {@code example.tar.gz}, only the last one should be
+   *       captured {@code gz}, not {@code tar.gz}.
+   * </ul>
+   */
+  public static final AttributeKey<String> URL_EXTENSION = stringKey("url.extension");
 
   /**
    * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.5">URI fragment</a> component
@@ -35,8 +64,8 @@ public final class UrlIncubatingAttributes {
    *       form of {@code https://username:password@www.example.com/}. In such case username and
    *       password SHOULD be redacted and attribute's value SHOULD be {@code
    *       https://REDACTED:REDACTED@www.example.com/}. {@code url.full} SHOULD capture the absolute
-   *       URL when it is available (or can be reconstructed) and SHOULD NOT be validated or
-   *       modified except for sanitizing purposes.
+   *       URL when it is available (or can be reconstructed). Sensitive content provided in {@code
+   *       url.full} SHOULD be scrubbed when instrumentations can identify it.
    * </ul>
    *
    * @deprecated deprecated in favor of stable {@link
@@ -45,12 +74,37 @@ public final class UrlIncubatingAttributes {
   @Deprecated public static final AttributeKey<String> URL_FULL = stringKey("url.full");
 
   /**
+   * Unmodified original URL as seen in the event source.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>In network monitoring, the observed URL may be a full URL, whereas in access logs, the
+   *       URL is often just represented as a path. This field is meant to represent the URL as it
+   *       was observed, complete or not. {@code url.original} might contain credentials passed via
+   *       URL in form of {@code https://username:password@www.example.com/}. In such case password
+   *       and username SHOULD NOT be redacted and attribute's value SHOULD remain the same.
+   * </ul>
+   */
+  public static final AttributeKey<String> URL_ORIGINAL = stringKey("url.original");
+
+  /**
    * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.3">URI path</a> component
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Sensitive content provided in {@code url.path} SHOULD be scrubbed when instrumentations
+   *       can identify it.
+   * </ul>
    *
    * @deprecated deprecated in favor of stable {@link
    *     io.opentelemetry.semconv.UrlAttributes#URL_PATH} attribute.
    */
   @Deprecated public static final AttributeKey<String> URL_PATH = stringKey("url.path");
+
+  /** Port extracted from the {@code url.full} */
+  public static final AttributeKey<Long> URL_PORT = longKey("url.port");
 
   /**
    * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.4">URI query</a> component
@@ -58,14 +112,29 @@ public final class UrlIncubatingAttributes {
    * <p>Notes:
    *
    * <ul>
-   *   <li>Sensitive content provided in query string SHOULD be scrubbed when instrumentations can
-   *       identify it.
+   *   <li>Sensitive content provided in {@code url.query} SHOULD be scrubbed when instrumentations
+   *       can identify it.
    * </ul>
    *
    * @deprecated deprecated in favor of stable {@link
    *     io.opentelemetry.semconv.UrlAttributes#URL_QUERY} attribute.
    */
   @Deprecated public static final AttributeKey<String> URL_QUERY = stringKey("url.query");
+
+  /**
+   * The highest registered url domain, stripped of the subdomain.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This value can be determined precisely with the <a href="http://publicsuffix.org">public
+   *       suffix list</a>. For example, the registered domain for {@code foo.example.com} is {@code
+   *       example.com}. Trying to approximate this by simply taking the last two labels will not
+   *       work well for TLDs such as {@code co.uk}.
+   * </ul>
+   */
+  public static final AttributeKey<String> URL_REGISTERED_DOMAIN =
+      stringKey("url.registered_domain");
 
   /**
    * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.1">URI scheme</a> component
@@ -75,6 +144,35 @@ public final class UrlIncubatingAttributes {
    *     io.opentelemetry.semconv.UrlAttributes#URL_SCHEME} attribute.
    */
   @Deprecated public static final AttributeKey<String> URL_SCHEME = stringKey("url.scheme");
+
+  /**
+   * The subdomain portion of a fully qualified domain name includes all of the names except the
+   * host name under the registered_domain. In a partially qualified domain, or if the qualification
+   * level of the full name cannot be determined, subdomain contains all of the names below the
+   * registered domain.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The subdomain portion of {@code www.east.mydomain.co.uk} is {@code east}. If the domain
+   *       has multiple levels of subdomain, such as {@code sub2.sub1.example.com}, the subdomain
+   *       field should contain {@code sub2.sub1}, with no trailing period.
+   * </ul>
+   */
+  public static final AttributeKey<String> URL_SUBDOMAIN = stringKey("url.subdomain");
+
+  /**
+   * The effective top level domain (eTLD), also known as the domain suffix, is the last part of the
+   * domain name. For example, the top level domain for example.com is {@code com}.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This value can be determined precisely with the <a href="http://publicsuffix.org">public
+   *       suffix list</a>.
+   * </ul>
+   */
+  public static final AttributeKey<String> URL_TOP_LEVEL_DOMAIN = stringKey("url.top_level_domain");
 
   private UrlIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/UserAgentIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/UserAgentIncubatingAttributes.java
@@ -15,6 +15,21 @@ import io.opentelemetry.api.common.AttributeKey;
 public final class UserAgentIncubatingAttributes {
 
   /**
+   * Name of the user-agent extracted from original. Usually refers to the browser's name.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li><a href="https://www.whatsmyua.info">Example</a> of extracting browser's name from
+   *       original string. In the case of using a user-agent for non-browser products, such as
+   *       microservices with multiple names/versions inside the {@code user_agent.original}, the
+   *       most significant name SHOULD be selected. In such a scenario it should align with {@code
+   *       user_agent.version}
+   * </ul>
+   */
+  public static final AttributeKey<String> USER_AGENT_NAME = stringKey("user_agent.name");
+
+  /**
    * Value of the <a href="https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent">HTTP
    * User-Agent</a> header sent by the client.
    *
@@ -23,6 +38,21 @@ public final class UserAgentIncubatingAttributes {
    */
   @Deprecated
   public static final AttributeKey<String> USER_AGENT_ORIGINAL = stringKey("user_agent.original");
+
+  /**
+   * Version of the user-agent extracted from original. Usually refers to the browser's version
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li><a href="https://www.whatsmyua.info">Example</a> of extracting browser's version from
+   *       original string. In the case of using a user-agent for non-browser products, such as
+   *       microservices with multiple names/versions inside the {@code user_agent.original}, the
+   *       most significant version SHOULD be selected. In such a scenario it should align with
+   *       {@code user_agent.name}
+   * </ul>
+   */
+  public static final AttributeKey<String> USER_AGENT_VERSION = stringKey("user_agent.version");
 
   private UserAgentIncubatingAttributes() {}
 }

--- a/semconv/src/main/java/io/opentelemetry/semconv/ExceptionAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/ExceptionAttributes.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.semconv.incubating;
+package io.opentelemetry.semconv;
 
 import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
@@ -13,7 +13,7 @@ import io.opentelemetry.api.common.AttributeKey;
 // DO NOT EDIT, this is an Auto-generated file from
 // buildscripts/templates/SemanticAttributes.java.j2
 @SuppressWarnings("unused")
-public final class ExceptionIncubatingAttributes {
+public final class ExceptionAttributes {
 
   /**
    * SHOULD be set to true if the exception event is recorded at a point where it is known that the
@@ -35,40 +35,23 @@ public final class ExceptionIncubatingAttributes {
    *       exception.escaped} attribute was not set or set to false, since the event might have been
    *       recorded at a time where it was not clear whether the exception will escape.
    * </ul>
-   *
-   * @deprecated deprecated in favor of stable {@link
-   *     io.opentelemetry.semconv.ExceptionAttributes#EXCEPTION_ESCAPED} attribute.
    */
-  @Deprecated
   public static final AttributeKey<Boolean> EXCEPTION_ESCAPED = booleanKey("exception.escaped");
 
-  /**
-   * The exception message.
-   *
-   * @deprecated deprecated in favor of stable {@link
-   *     io.opentelemetry.semconv.ExceptionAttributes#EXCEPTION_MESSAGE} attribute.
-   */
-  @Deprecated
+  /** The exception message. */
   public static final AttributeKey<String> EXCEPTION_MESSAGE = stringKey("exception.message");
 
   /**
    * A stacktrace as a string in the natural representation for the language runtime. The
    * representation is to be determined and documented by each language SIG.
-   *
-   * @deprecated deprecated in favor of stable {@link
-   *     io.opentelemetry.semconv.ExceptionAttributes#EXCEPTION_STACKTRACE} attribute.
    */
-  @Deprecated
   public static final AttributeKey<String> EXCEPTION_STACKTRACE = stringKey("exception.stacktrace");
 
   /**
    * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of
    * the exception should be preferred over the static type in languages that support it.
-   *
-   * @deprecated deprecated in favor of stable {@link
-   *     io.opentelemetry.semconv.ExceptionAttributes#EXCEPTION_TYPE} attribute.
    */
-  @Deprecated public static final AttributeKey<String> EXCEPTION_TYPE = stringKey("exception.type");
+  public static final AttributeKey<String> EXCEPTION_TYPE = stringKey("exception.type");
 
-  private ExceptionIncubatingAttributes() {}
+  private ExceptionAttributes() {}
 }

--- a/semconv/src/main/java/io/opentelemetry/semconv/NetworkAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/NetworkAttributes.java
@@ -42,14 +42,15 @@ public final class NetworkAttributes {
       stringKey("network.protocol.name");
 
   /**
-   * Version of the protocol specified in {@code network.protocol.name}.
+   * The actual version of the protocol used for network communication.
    *
    * <p>Notes:
    *
    * <ul>
-   *   <li>{@code network.protocol.version} refers to the version of the protocol used and might be
-   *       different from the protocol client's version. If the HTTP client has a version of {@code
-   *       0.27.2}, but sends HTTP version {@code 1.1}, this attribute should be set to {@code 1.1}.
+   *   <li>If protocol version is subject to negotiation (for example using <a
+   *       href="https://www.rfc-editor.org/rfc/rfc7301.html">ALPN</a>), this attribute SHOULD be
+   *       set to the negotiated version. If the actual protocol version is not known, this
+   *       attribute SHOULD NOT be set.
    * </ul>
    */
   public static final AttributeKey<String> NETWORK_PROTOCOL_VERSION =

--- a/semconv/src/main/java/io/opentelemetry/semconv/OtelAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/OtelAttributes.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.semconv;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+// DO NOT EDIT, this is an Auto-generated file from
+// buildscripts/templates/SemanticAttributes.java.j2
+@SuppressWarnings("unused")
+public final class OtelAttributes {
+
+  /** The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP). */
+  public static final AttributeKey<String> OTEL_SCOPE_NAME = stringKey("otel.scope.name");
+
+  /** The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP). */
+  public static final AttributeKey<String> OTEL_SCOPE_VERSION = stringKey("otel.scope.version");
+
+  /**
+   * Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set if the status
+   * code is UNSET.
+   */
+  public static final AttributeKey<String> OTEL_STATUS_CODE = stringKey("otel.status_code");
+
+  /** Description of the Status if it has a value, otherwise not set. */
+  public static final AttributeKey<String> OTEL_STATUS_DESCRIPTION =
+      stringKey("otel.status_description");
+
+  // Enum definitions
+  /** Values for {@link #OTEL_STATUS_CODE}. */
+  public static final class OtelStatusCodeValues {
+    /**
+     * The operation has been validated by an Application developer or Operator to have completed
+     * successfully.
+     */
+    public static final String OK = "OK";
+
+    /** The operation contains an error. */
+    public static final String ERROR = "ERROR";
+
+    private OtelStatusCodeValues() {}
+  }
+
+  private OtelAttributes() {}
+}

--- a/semconv/src/main/java/io/opentelemetry/semconv/ResourceAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/ResourceAttributes.java
@@ -15,17 +15,18 @@ import io.opentelemetry.api.common.AttributeKey;
 import java.util.List;
 
 /**
- * @deprecated This class is deprecated and will be removed in a future release. It is only provided as a
- * convenience to help migration to the new semantic conventions classes structure that was introduced
- * in version 1.24.0.
+ * @deprecated This class is deprecated and will be removed in a future release. It is only provided
+ *     as a convenience to help migration to the new semantic conventions classes structure that was
+ *     introduced in version 1.24.0.
  */
 @Deprecated
 @SuppressWarnings("unused")
 public final class ResourceAttributes {
   /** The URL of the OpenTelemetry schema for these keys and values. */
-  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.23.1";
+  @Deprecated public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.23.1";
 
   /** The cloud account ID the resource is assigned to. */
+  @Deprecated
   public static final AttributeKey<String> CLOUD_ACCOUNT_ID = stringKey("cloud.account.id");
 
   /**
@@ -38,6 +39,7 @@ public final class ResourceAttributes {
    *   <li>Availability zones are called &quot;zones&quot; on Alibaba Cloud and Google Cloud.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> CLOUD_AVAILABILITY_ZONE =
       stringKey("cloud.availability_zone");
 
@@ -50,10 +52,10 @@ public final class ResourceAttributes {
    *   <li>The prefix of the service SHOULD match the one specified in {@code cloud.provider}.
    * </ul>
    */
-  public static final AttributeKey<String> CLOUD_PLATFORM = stringKey("cloud.platform");
+  @Deprecated public static final AttributeKey<String> CLOUD_PLATFORM = stringKey("cloud.platform");
 
   /** Name of the cloud provider. */
-  public static final AttributeKey<String> CLOUD_PROVIDER = stringKey("cloud.provider");
+  @Deprecated public static final AttributeKey<String> CLOUD_PROVIDER = stringKey("cloud.provider");
 
   /**
    * The geographical region the resource is running.
@@ -70,7 +72,7 @@ public final class ResourceAttributes {
    *       href="https://www.tencentcloud.com/document/product/213/6091">Tencent Cloud regions</a>.
    * </ul>
    */
-  public static final AttributeKey<String> CLOUD_REGION = stringKey("cloud.region");
+  @Deprecated public static final AttributeKey<String> CLOUD_REGION = stringKey("cloud.region");
 
   /**
    * Cloud provider-specific native identifier of the monitored cloud resource (e.g. an <a
@@ -104,6 +106,7 @@ public final class ResourceAttributes {
    *       functions that would usually share a TracerProvider.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> CLOUD_RESOURCE_ID = stringKey("cloud.resource_id");
 
   /**
@@ -116,15 +119,18 @@ public final class ResourceAttributes {
    *       prevent potential leakage.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> CONTAINER_COMMAND = stringKey("container.command");
 
   /**
    * All the command arguments (including the command/executable itself) run by the container. [2]
    */
+  @Deprecated
   public static final AttributeKey<List<String>> CONTAINER_COMMAND_ARGS =
       stringArrayKey("container.command_args");
 
   /** The full command run by the container as a single string representing the full command. [2] */
+  @Deprecated
   public static final AttributeKey<String> CONTAINER_COMMAND_LINE =
       stringKey("container.command_line");
 
@@ -133,7 +139,7 @@ public final class ResourceAttributes {
    * href="https://docs.docker.com/engine/reference/run/#container-identification">identify Docker
    * containers</a>. The UUID might be abbreviated.
    */
-  public static final AttributeKey<String> CONTAINER_ID = stringKey("container.id");
+  @Deprecated public static final AttributeKey<String> CONTAINER_ID = stringKey("container.id");
 
   /**
    * Runtime specific image identifier. Usually a hash algorithm followed by a UUID.
@@ -152,9 +158,11 @@ public final class ResourceAttributes {
    *       in different environments/runtimes.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> CONTAINER_IMAGE_ID = stringKey("container.image.id");
 
   /** Name of the image the container was built on. */
+  @Deprecated
   public static final AttributeKey<String> CONTAINER_IMAGE_NAME = stringKey("container.image.name");
 
   /**
@@ -170,6 +178,7 @@ public final class ResourceAttributes {
    *       report those under the {@code RepoDigests} field.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<List<String>> CONTAINER_IMAGE_REPO_DIGESTS =
       stringArrayKey("container.image.repo_digests");
 
@@ -179,13 +188,15 @@ public final class ResourceAttributes {
    * Inspect</a>. Should be only the {@code <tag>} section of the full name for example from {@code
    * registry.example.com/my-org/my-image:<tag>}.
    */
+  @Deprecated
   public static final AttributeKey<List<String>> CONTAINER_IMAGE_TAGS =
       stringArrayKey("container.image.tags");
 
   /** Container name used by container runtime. */
-  public static final AttributeKey<String> CONTAINER_NAME = stringKey("container.name");
+  @Deprecated public static final AttributeKey<String> CONTAINER_NAME = stringKey("container.name");
 
   /** The container runtime managing this container. */
+  @Deprecated
   public static final AttributeKey<String> CONTAINER_RUNTIME = stringKey("container.runtime");
 
   /**
@@ -203,6 +214,7 @@ public final class ResourceAttributes {
    *       Image Manifest</a>.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> OCI_MANIFEST_DIGEST = stringKey("oci.manifest.digest");
 
   /**
@@ -210,6 +222,7 @@ public final class ResourceAttributes {
    * android operating system. More information can be found <a
    * href="https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels">here</a>.
    */
+  @Deprecated
   public static final AttributeKey<String> ANDROID_OS_API_LEVEL = stringKey("android.os.api_level");
 
   /**
@@ -223,6 +236,7 @@ public final class ResourceAttributes {
    *       navigator.userAgentData.brands}).
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<List<String>> BROWSER_BRANDS = stringArrayKey("browser.brands");
 
   /**
@@ -234,6 +248,7 @@ public final class ResourceAttributes {
    *   <li>This value is intended to be taken from the Navigator API {@code navigator.language}.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> BROWSER_LANGUAGE = stringKey("browser.language");
 
   /**
@@ -247,6 +262,7 @@ public final class ResourceAttributes {
    *       navigator.userAgentData.mobile}). If unavailable, this attribute SHOULD be left unset.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<Boolean> BROWSER_MOBILE = booleanKey("browser.mobile");
 
   /**
@@ -267,6 +283,7 @@ public final class ResourceAttributes {
    *       capture the exact value that the user agent provides.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> BROWSER_PLATFORM = stringKey("browser.platform");
 
   /**
@@ -274,6 +291,7 @@ public final class ResourceAttributes {
    * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html">ECS
    * cluster</a>.
    */
+  @Deprecated
   public static final AttributeKey<String> AWS_ECS_CLUSTER_ARN = stringKey("aws.ecs.cluster.arn");
 
   /**
@@ -281,6 +299,7 @@ public final class ResourceAttributes {
    * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html">ECS
    * container instance</a>.
    */
+  @Deprecated
   public static final AttributeKey<String> AWS_ECS_CONTAINER_ARN =
       stringKey("aws.ecs.container.arn");
 
@@ -289,6 +308,7 @@ public final class ResourceAttributes {
    * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html">launch
    * type</a> for an ECS task.
    */
+  @Deprecated
   public static final AttributeKey<String> AWS_ECS_LAUNCHTYPE = stringKey("aws.ecs.launchtype");
 
   /**
@@ -296,16 +316,20 @@ public final class ResourceAttributes {
    * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html">ECS
    * task definition</a>.
    */
+  @Deprecated
   public static final AttributeKey<String> AWS_ECS_TASK_ARN = stringKey("aws.ecs.task.arn");
 
   /** The task definition family this task definition is a member of. */
+  @Deprecated
   public static final AttributeKey<String> AWS_ECS_TASK_FAMILY = stringKey("aws.ecs.task.family");
 
   /** The revision for this task definition. */
+  @Deprecated
   public static final AttributeKey<String> AWS_ECS_TASK_REVISION =
       stringKey("aws.ecs.task.revision");
 
   /** The ARN of an EKS cluster. */
+  @Deprecated
   public static final AttributeKey<String> AWS_EKS_CLUSTER_ARN = stringKey("aws.eks.cluster.arn");
 
   /**
@@ -319,6 +343,7 @@ public final class ResourceAttributes {
    *       group ARN format documentation</a>.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<List<String>> AWS_LOG_GROUP_ARNS =
       stringArrayKey("aws.log.group.arns");
 
@@ -332,6 +357,7 @@ public final class ResourceAttributes {
    *       a single application has sidecar containers, and each write to their own log group.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<List<String>> AWS_LOG_GROUP_NAMES =
       stringArrayKey("aws.log.group.names");
 
@@ -347,10 +373,12 @@ public final class ResourceAttributes {
    *       these ARNs necessarily identify both a log group and a log stream.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<List<String>> AWS_LOG_STREAM_ARNS =
       stringArrayKey("aws.log.stream.arns");
 
   /** The name(s) of the AWS log stream(s) an application is writing to. */
+  @Deprecated
   public static final AttributeKey<List<String>> AWS_LOG_STREAM_NAMES =
       stringArrayKey("aws.log.stream.names");
 
@@ -361,6 +389,7 @@ public final class ResourceAttributes {
    * href="https://cloud.google.com/run/docs/container-contract#jobs-env-vars">{@code
    * CLOUD_RUN_EXECUTION}</a> environment variable.
    */
+  @Deprecated
   public static final AttributeKey<String> GCP_CLOUD_RUN_JOB_EXECUTION =
       stringKey("gcp.cloud_run.job.execution");
 
@@ -369,6 +398,7 @@ public final class ResourceAttributes {
    * href="https://cloud.google.com/run/docs/container-contract#jobs-env-vars">{@code
    * CLOUD_RUN_TASK_INDEX}</a> environment variable.
    */
+  @Deprecated
   public static final AttributeKey<Long> GCP_CLOUD_RUN_JOB_TASK_INDEX =
       longKey("gcp.cloud_run.job.task_index");
 
@@ -376,6 +406,7 @@ public final class ResourceAttributes {
    * The hostname of a GCE instance. This is the full value of the default or <a
    * href="https://cloud.google.com/compute/docs/instances/custom-hostname-vm">custom hostname</a>.
    */
+  @Deprecated
   public static final AttributeKey<String> GCP_GCE_INSTANCE_HOSTNAME =
       stringKey("gcp.gce.instance.hostname");
 
@@ -386,17 +417,20 @@ public final class ResourceAttributes {
    * href="https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names">default
    * internal DNS name</a>.
    */
+  @Deprecated
   public static final AttributeKey<String> GCP_GCE_INSTANCE_NAME =
       stringKey("gcp.gce.instance.name");
 
   /** Unique identifier for the application */
-  public static final AttributeKey<String> HEROKU_APP_ID = stringKey("heroku.app.id");
+  @Deprecated public static final AttributeKey<String> HEROKU_APP_ID = stringKey("heroku.app.id");
 
   /** Commit hash for the current release */
+  @Deprecated
   public static final AttributeKey<String> HEROKU_RELEASE_COMMIT =
       stringKey("heroku.release.commit");
 
   /** Time and date the release was created */
+  @Deprecated
   public static final AttributeKey<String> HEROKU_RELEASE_CREATION_TIMESTAMP =
       stringKey("heroku.release.creation_timestamp");
 
@@ -404,6 +438,7 @@ public final class ResourceAttributes {
    * Name of the <a href="https://wikipedia.org/wiki/Deployment_environment">deployment
    * environment</a> (aka deployment tier).
    */
+  @Deprecated
   public static final AttributeKey<String> DEPLOYMENT_ENVIRONMENT =
       stringKey("deployment.environment");
 
@@ -426,7 +461,7 @@ public final class ResourceAttributes {
    *       ensure you do your own due diligence.
    * </ul>
    */
-  public static final AttributeKey<String> DEVICE_ID = stringKey("device.id");
+  @Deprecated public static final AttributeKey<String> DEVICE_ID = stringKey("device.id");
 
   /**
    * The name of the device manufacturer
@@ -439,6 +474,7 @@ public final class ResourceAttributes {
    *       iOS apps SHOULD hardcode the value {@code Apple}.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> DEVICE_MANUFACTURER = stringKey("device.manufacturer");
 
   /**
@@ -451,6 +487,7 @@ public final class ResourceAttributes {
    *       rather than the market or consumer-friendly name of the device.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> DEVICE_MODEL_IDENTIFIER =
       stringKey("device.model.identifier");
 
@@ -464,6 +501,7 @@ public final class ResourceAttributes {
    *       rather than a machine readable alternative.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> DEVICE_MODEL_NAME = stringKey("device.model.name");
 
   /**
@@ -476,7 +514,7 @@ public final class ResourceAttributes {
    *   <li><strong>AWS Lambda:</strong> Use the (full) log stream name.
    * </ul>
    */
-  public static final AttributeKey<String> FAAS_INSTANCE = stringKey("faas.instance");
+  @Deprecated public static final AttributeKey<String> FAAS_INSTANCE = stringKey("faas.instance");
 
   /**
    * The amount of memory available to the serverless function converted to Bytes.
@@ -490,7 +528,7 @@ public final class ResourceAttributes {
    *       multiplied by 1,048,576).
    * </ul>
    */
-  public static final AttributeKey<Long> FAAS_MAX_MEMORY = longKey("faas.max_memory");
+  @Deprecated public static final AttributeKey<Long> FAAS_MAX_MEMORY = longKey("faas.max_memory");
 
   /**
    * The name of the single function that this runtime instance executes.
@@ -512,7 +550,7 @@ public final class ResourceAttributes {
    *       (see also the {@code cloud.resource_id} attribute).
    * </ul>
    */
-  public static final AttributeKey<String> FAAS_NAME = stringKey("faas.name");
+  @Deprecated public static final AttributeKey<String> FAAS_NAME = stringKey("faas.name");
 
   /**
    * The immutable version of the function being executed.
@@ -533,28 +571,30 @@ public final class ResourceAttributes {
    *   <li><strong>Azure Functions:</strong> Not applicable. Do not set this attribute.
    * </ul>
    */
-  public static final AttributeKey<String> FAAS_VERSION = stringKey("faas.version");
+  @Deprecated public static final AttributeKey<String> FAAS_VERSION = stringKey("faas.version");
 
   /** The CPU architecture the host system is running on. */
-  public static final AttributeKey<String> HOST_ARCH = stringKey("host.arch");
+  @Deprecated public static final AttributeKey<String> HOST_ARCH = stringKey("host.arch");
 
   /**
    * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For
    * non-containerized systems, this should be the {@code machine-id}. See the table below for the
    * sources to use to determine the {@code machine-id} based on operating system.
    */
-  public static final AttributeKey<String> HOST_ID = stringKey("host.id");
+  @Deprecated public static final AttributeKey<String> HOST_ID = stringKey("host.id");
 
   /** VM image ID or host OS image ID. For Cloud, this value is from the provider. */
-  public static final AttributeKey<String> HOST_IMAGE_ID = stringKey("host.image.id");
+  @Deprecated public static final AttributeKey<String> HOST_IMAGE_ID = stringKey("host.image.id");
 
   /** Name of the VM image or OS install the host was instantiated from. */
+  @Deprecated
   public static final AttributeKey<String> HOST_IMAGE_NAME = stringKey("host.image.name");
 
   /**
    * The version string of the VM image or host OS as defined in <a
    * href="README.md#version-attributes">Version Attributes</a>.
    */
+  @Deprecated
   public static final AttributeKey<String> HOST_IMAGE_VERSION = stringKey("host.image.version");
 
   /**
@@ -568,7 +608,7 @@ public final class ResourceAttributes {
    *       format.
    * </ul>
    */
-  public static final AttributeKey<List<String>> HOST_IP = stringArrayKey("host.ip");
+  @Deprecated public static final AttributeKey<List<String>> HOST_IP = stringArrayKey("host.ip");
 
   /**
    * Available MAC addresses of the host, excluding loopback interfaces.
@@ -582,33 +622,37 @@ public final class ResourceAttributes {
    *       most to least significant.
    * </ul>
    */
-  public static final AttributeKey<List<String>> HOST_MAC = stringArrayKey("host.mac");
+  @Deprecated public static final AttributeKey<List<String>> HOST_MAC = stringArrayKey("host.mac");
 
   /**
    * Name of the host. On Unix systems, it may contain what the hostname command returns, or the
    * fully qualified hostname, or another name specified by the user.
    */
-  public static final AttributeKey<String> HOST_NAME = stringKey("host.name");
+  @Deprecated public static final AttributeKey<String> HOST_NAME = stringKey("host.name");
 
   /** Type of host. For Cloud, this must be the machine type. */
-  public static final AttributeKey<String> HOST_TYPE = stringKey("host.type");
+  @Deprecated public static final AttributeKey<String> HOST_TYPE = stringKey("host.type");
 
   /** The amount of level 2 memory cache available to the processor (in Bytes). */
+  @Deprecated
   public static final AttributeKey<Long> HOST_CPU_CACHE_L2_SIZE = longKey("host.cpu.cache.l2.size");
 
   /** Numeric value specifying the family or generation of the CPU. */
-  public static final AttributeKey<Long> HOST_CPU_FAMILY = longKey("host.cpu.family");
+  @Deprecated public static final AttributeKey<Long> HOST_CPU_FAMILY = longKey("host.cpu.family");
 
   /**
    * Model identifier. It provides more granular information about the CPU, distinguishing it from
    * other CPUs within the same family.
    */
+  @Deprecated
   public static final AttributeKey<Long> HOST_CPU_MODEL_ID = longKey("host.cpu.model.id");
 
   /** Model designation of the processor. */
+  @Deprecated
   public static final AttributeKey<String> HOST_CPU_MODEL_NAME = stringKey("host.cpu.model.name");
 
   /** Stepping or core revisions. */
+  @Deprecated
   public static final AttributeKey<Long> HOST_CPU_STEPPING = longKey("host.cpu.stepping");
 
   /**
@@ -622,9 +666,11 @@ public final class ResourceAttributes {
    *       12-character string.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> HOST_CPU_VENDOR_ID = stringKey("host.cpu.vendor.id");
 
   /** The name of the cluster. */
+  @Deprecated
   public static final AttributeKey<String> K8S_CLUSTER_NAME = stringKey("k8s.cluster.name");
 
   /**
@@ -650,98 +696,113 @@ public final class ResourceAttributes {
    *   <li>Therefore, UIDs between clusters should be extremely unlikely to conflict.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> K8S_CLUSTER_UID = stringKey("k8s.cluster.uid");
 
   /** The name of the Node. */
-  public static final AttributeKey<String> K8S_NODE_NAME = stringKey("k8s.node.name");
+  @Deprecated public static final AttributeKey<String> K8S_NODE_NAME = stringKey("k8s.node.name");
 
   /** The UID of the Node. */
-  public static final AttributeKey<String> K8S_NODE_UID = stringKey("k8s.node.uid");
+  @Deprecated public static final AttributeKey<String> K8S_NODE_UID = stringKey("k8s.node.uid");
 
   /** The name of the namespace that the pod is running in. */
+  @Deprecated
   public static final AttributeKey<String> K8S_NAMESPACE_NAME = stringKey("k8s.namespace.name");
 
   /** The name of the Pod. */
-  public static final AttributeKey<String> K8S_POD_NAME = stringKey("k8s.pod.name");
+  @Deprecated public static final AttributeKey<String> K8S_POD_NAME = stringKey("k8s.pod.name");
 
   /** The UID of the Pod. */
-  public static final AttributeKey<String> K8S_POD_UID = stringKey("k8s.pod.uid");
+  @Deprecated public static final AttributeKey<String> K8S_POD_UID = stringKey("k8s.pod.uid");
 
   /**
    * The name of the Container from Pod specification, must be unique within a Pod. Container
    * runtime usually uses different globally unique name ({@code container.name}).
    */
+  @Deprecated
   public static final AttributeKey<String> K8S_CONTAINER_NAME = stringKey("k8s.container.name");
 
   /**
    * Number of times the container was restarted. This attribute can be used to identify a
    * particular container (running or stopped) within a container spec.
    */
+  @Deprecated
   public static final AttributeKey<Long> K8S_CONTAINER_RESTART_COUNT =
       longKey("k8s.container.restart_count");
 
   /** The name of the ReplicaSet. */
+  @Deprecated
   public static final AttributeKey<String> K8S_REPLICASET_NAME = stringKey("k8s.replicaset.name");
 
   /** The UID of the ReplicaSet. */
+  @Deprecated
   public static final AttributeKey<String> K8S_REPLICASET_UID = stringKey("k8s.replicaset.uid");
 
   /** The name of the Deployment. */
+  @Deprecated
   public static final AttributeKey<String> K8S_DEPLOYMENT_NAME = stringKey("k8s.deployment.name");
 
   /** The UID of the Deployment. */
+  @Deprecated
   public static final AttributeKey<String> K8S_DEPLOYMENT_UID = stringKey("k8s.deployment.uid");
 
   /** The name of the StatefulSet. */
+  @Deprecated
   public static final AttributeKey<String> K8S_STATEFULSET_NAME = stringKey("k8s.statefulset.name");
 
   /** The UID of the StatefulSet. */
+  @Deprecated
   public static final AttributeKey<String> K8S_STATEFULSET_UID = stringKey("k8s.statefulset.uid");
 
   /** The name of the DaemonSet. */
+  @Deprecated
   public static final AttributeKey<String> K8S_DAEMONSET_NAME = stringKey("k8s.daemonset.name");
 
   /** The UID of the DaemonSet. */
+  @Deprecated
   public static final AttributeKey<String> K8S_DAEMONSET_UID = stringKey("k8s.daemonset.uid");
 
   /** The name of the Job. */
-  public static final AttributeKey<String> K8S_JOB_NAME = stringKey("k8s.job.name");
+  @Deprecated public static final AttributeKey<String> K8S_JOB_NAME = stringKey("k8s.job.name");
 
   /** The UID of the Job. */
-  public static final AttributeKey<String> K8S_JOB_UID = stringKey("k8s.job.uid");
+  @Deprecated public static final AttributeKey<String> K8S_JOB_UID = stringKey("k8s.job.uid");
 
   /** The name of the CronJob. */
+  @Deprecated
   public static final AttributeKey<String> K8S_CRONJOB_NAME = stringKey("k8s.cronjob.name");
 
   /** The UID of the CronJob. */
+  @Deprecated
   public static final AttributeKey<String> K8S_CRONJOB_UID = stringKey("k8s.cronjob.uid");
 
   /** Unique identifier for a particular build or compilation of the operating system. */
-  public static final AttributeKey<String> OS_BUILD_ID = stringKey("os.build_id");
+  @Deprecated public static final AttributeKey<String> OS_BUILD_ID = stringKey("os.build_id");
 
   /**
    * Human readable (not intended to be parsed) OS version information, like e.g. reported by {@code
    * ver} or {@code lsb_release -a} commands.
    */
-  public static final AttributeKey<String> OS_DESCRIPTION = stringKey("os.description");
+  @Deprecated public static final AttributeKey<String> OS_DESCRIPTION = stringKey("os.description");
 
   /** Human readable operating system name. */
-  public static final AttributeKey<String> OS_NAME = stringKey("os.name");
+  @Deprecated public static final AttributeKey<String> OS_NAME = stringKey("os.name");
 
   /** The operating system type. */
-  public static final AttributeKey<String> OS_TYPE = stringKey("os.type");
+  @Deprecated public static final AttributeKey<String> OS_TYPE = stringKey("os.type");
 
   /**
    * The version string of the operating system as defined in <a
    * href="/docs/resource/README.md#version-attributes">Version Attributes</a>.
    */
-  public static final AttributeKey<String> OS_VERSION = stringKey("os.version");
+  @Deprecated public static final AttributeKey<String> OS_VERSION = stringKey("os.version");
 
   /**
    * The command used to launch the process (i.e. the command name). On Linux based systems, can be
    * set to the zeroth string in {@code proc/[pid]/cmdline}. On Windows, can be set to the first
    * parameter extracted from {@code GetCommandLineW}.
    */
+  @Deprecated
   public static final AttributeKey<String> PROCESS_COMMAND = stringKey("process.command");
 
   /**
@@ -750,6 +811,7 @@ public final class ResourceAttributes {
    * to the list of null-delimited strings extracted from {@code proc/[pid]/cmdline}. For libc-based
    * executables, this would be the full argv vector passed to {@code main}.
    */
+  @Deprecated
   public static final AttributeKey<List<String>> PROCESS_COMMAND_ARGS =
       stringArrayKey("process.command_args");
 
@@ -758,6 +820,7 @@ public final class ResourceAttributes {
    * On Windows, can be set to the result of {@code GetCommandLineW}. Do not set this if you have to
    * assemble it just for monitoring; use {@code process.command_args} instead.
    */
+  @Deprecated
   public static final AttributeKey<String> PROCESS_COMMAND_LINE = stringKey("process.command_line");
 
   /**
@@ -765,6 +828,7 @@ public final class ResourceAttributes {
    * {@code proc/[pid]/status}. On Windows, can be set to the base name of {@code
    * GetProcessImageFileNameW}.
    */
+  @Deprecated
   public static final AttributeKey<String> PROCESS_EXECUTABLE_NAME =
       stringKey("process.executable.name");
 
@@ -773,22 +837,25 @@ public final class ResourceAttributes {
    * {@code proc/[pid]/exe}. On Windows, can be set to the result of {@code
    * GetProcessImageFileNameW}.
    */
+  @Deprecated
   public static final AttributeKey<String> PROCESS_EXECUTABLE_PATH =
       stringKey("process.executable.path");
 
   /** The username of the user that owns the process. */
-  public static final AttributeKey<String> PROCESS_OWNER = stringKey("process.owner");
+  @Deprecated public static final AttributeKey<String> PROCESS_OWNER = stringKey("process.owner");
 
   /** Parent Process identifier (PID). */
+  @Deprecated
   public static final AttributeKey<Long> PROCESS_PARENT_PID = longKey("process.parent_pid");
 
   /** Process identifier (PID). */
-  public static final AttributeKey<Long> PROCESS_PID = longKey("process.pid");
+  @Deprecated public static final AttributeKey<Long> PROCESS_PID = longKey("process.pid");
 
   /**
    * An additional description about the runtime of the process, for example a specific vendor
    * customization of the runtime environment.
    */
+  @Deprecated
   public static final AttributeKey<String> PROCESS_RUNTIME_DESCRIPTION =
       stringKey("process.runtime.description");
 
@@ -796,11 +863,13 @@ public final class ResourceAttributes {
    * The name of the runtime of this process. For compiled native binaries, this SHOULD be the name
    * of the compiler.
    */
+  @Deprecated
   public static final AttributeKey<String> PROCESS_RUNTIME_NAME = stringKey("process.runtime.name");
 
   /**
    * The version of the runtime of this process, as returned by the runtime without modification.
    */
+  @Deprecated
   public static final AttributeKey<String> PROCESS_RUNTIME_VERSION =
       stringKey("process.runtime.version");
 
@@ -817,12 +886,13 @@ public final class ResourceAttributes {
    *       MUST be set to {@code unknown_service}.
    * </ul>
    */
-  public static final AttributeKey<String> SERVICE_NAME = stringKey("service.name");
+  @Deprecated public static final AttributeKey<String> SERVICE_NAME = stringKey("service.name");
 
   /**
    * The version string of the service API or implementation. The format is not defined by these
    * conventions.
    */
+  @Deprecated
   public static final AttributeKey<String> SERVICE_VERSION = stringKey("service.version");
 
   /**
@@ -843,6 +913,7 @@ public final class ResourceAttributes {
    *       Version 5, see RFC 4122 for more recommendations).
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> SERVICE_INSTANCE_ID = stringKey("service.instance.id");
 
   /**
@@ -859,9 +930,11 @@ public final class ResourceAttributes {
    *       namespace). Zero-length namespace string is assumed equal to unspecified namespace.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> SERVICE_NAMESPACE = stringKey("service.namespace");
 
   /** The language of the telemetry SDK. */
+  @Deprecated
   public static final AttributeKey<String> TELEMETRY_SDK_LANGUAGE =
       stringKey("telemetry.sdk.language");
 
@@ -880,9 +953,11 @@ public final class ResourceAttributes {
    *       implementation.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> TELEMETRY_SDK_NAME = stringKey("telemetry.sdk.name");
 
   /** The version string of the telemetry SDK. */
+  @Deprecated
   public static final AttributeKey<String> TELEMETRY_SDK_VERSION =
       stringKey("telemetry.sdk.version");
 
@@ -897,27 +972,33 @@ public final class ResourceAttributes {
    *       {@code opentelemetry-java-instrumentation}.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> TELEMETRY_DISTRO_NAME =
       stringKey("telemetry.distro.name");
 
   /** The version string of the auto instrumentation agent or distribution, if used. */
+  @Deprecated
   public static final AttributeKey<String> TELEMETRY_DISTRO_VERSION =
       stringKey("telemetry.distro.version");
 
   /** Additional description of the web engine (e.g. detailed version and edition information). */
+  @Deprecated
   public static final AttributeKey<String> WEBENGINE_DESCRIPTION =
       stringKey("webengine.description");
 
   /** The name of the web engine. */
-  public static final AttributeKey<String> WEBENGINE_NAME = stringKey("webengine.name");
+  @Deprecated public static final AttributeKey<String> WEBENGINE_NAME = stringKey("webengine.name");
 
   /** The version of the web engine. */
+  @Deprecated
   public static final AttributeKey<String> WEBENGINE_VERSION = stringKey("webengine.version");
 
   /** The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP). */
+  @Deprecated
   public static final AttributeKey<String> OTEL_SCOPE_NAME = stringKey("otel.scope.name");
 
   /** The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP). */
+  @Deprecated
   public static final AttributeKey<String> OTEL_SCOPE_VERSION = stringKey("otel.scope.version");
 
   /**
@@ -937,231 +1018,238 @@ public final class ResourceAttributes {
   public static final AttributeKey<String> OTEL_LIBRARY_VERSION = stringKey("otel.library.version");
 
   /** Container labels, {@code <key>} being the label name, the value being the label value. */
+  @Deprecated
   public static final AttributeKeyTemplate<String> CONTAINER_LABELS =
       stringKeyTemplate("container.labels");
 
   // Enum definitions
+  @Deprecated
   public static final class CloudPlatformValues {
     /** Alibaba Cloud Elastic Compute Service. */
-    public static final String ALIBABA_CLOUD_ECS = "alibaba_cloud_ecs";
+    @Deprecated public static final String ALIBABA_CLOUD_ECS = "alibaba_cloud_ecs";
 
     /** Alibaba Cloud Function Compute. */
-    public static final String ALIBABA_CLOUD_FC = "alibaba_cloud_fc";
+    @Deprecated public static final String ALIBABA_CLOUD_FC = "alibaba_cloud_fc";
 
     /** Red Hat OpenShift on Alibaba Cloud. */
-    public static final String ALIBABA_CLOUD_OPENSHIFT = "alibaba_cloud_openshift";
+    @Deprecated public static final String ALIBABA_CLOUD_OPENSHIFT = "alibaba_cloud_openshift";
 
     /** AWS Elastic Compute Cloud. */
-    public static final String AWS_EC2 = "aws_ec2";
+    @Deprecated public static final String AWS_EC2 = "aws_ec2";
 
     /** AWS Elastic Container Service. */
-    public static final String AWS_ECS = "aws_ecs";
+    @Deprecated public static final String AWS_ECS = "aws_ecs";
 
     /** AWS Elastic Kubernetes Service. */
-    public static final String AWS_EKS = "aws_eks";
+    @Deprecated public static final String AWS_EKS = "aws_eks";
 
     /** AWS Lambda. */
-    public static final String AWS_LAMBDA = "aws_lambda";
+    @Deprecated public static final String AWS_LAMBDA = "aws_lambda";
 
     /** AWS Elastic Beanstalk. */
-    public static final String AWS_ELASTIC_BEANSTALK = "aws_elastic_beanstalk";
+    @Deprecated public static final String AWS_ELASTIC_BEANSTALK = "aws_elastic_beanstalk";
 
     /** AWS App Runner. */
-    public static final String AWS_APP_RUNNER = "aws_app_runner";
+    @Deprecated public static final String AWS_APP_RUNNER = "aws_app_runner";
 
     /** Red Hat OpenShift on AWS (ROSA). */
-    public static final String AWS_OPENSHIFT = "aws_openshift";
+    @Deprecated public static final String AWS_OPENSHIFT = "aws_openshift";
 
     /** Azure Virtual Machines. */
-    public static final String AZURE_VM = "azure_vm";
+    @Deprecated public static final String AZURE_VM = "azure_vm";
 
     /** Azure Container Instances. */
-    public static final String AZURE_CONTAINER_INSTANCES = "azure_container_instances";
+    @Deprecated public static final String AZURE_CONTAINER_INSTANCES = "azure_container_instances";
 
     /** Azure Kubernetes Service. */
-    public static final String AZURE_AKS = "azure_aks";
+    @Deprecated public static final String AZURE_AKS = "azure_aks";
 
     /** Azure Functions. */
-    public static final String AZURE_FUNCTIONS = "azure_functions";
+    @Deprecated public static final String AZURE_FUNCTIONS = "azure_functions";
 
     /** Azure App Service. */
-    public static final String AZURE_APP_SERVICE = "azure_app_service";
+    @Deprecated public static final String AZURE_APP_SERVICE = "azure_app_service";
 
     /** Azure Red Hat OpenShift. */
-    public static final String AZURE_OPENSHIFT = "azure_openshift";
+    @Deprecated public static final String AZURE_OPENSHIFT = "azure_openshift";
 
     /** Google Bare Metal Solution (BMS). */
-    public static final String GCP_BARE_METAL_SOLUTION = "gcp_bare_metal_solution";
+    @Deprecated public static final String GCP_BARE_METAL_SOLUTION = "gcp_bare_metal_solution";
 
     /** Google Cloud Compute Engine (GCE). */
-    public static final String GCP_COMPUTE_ENGINE = "gcp_compute_engine";
+    @Deprecated public static final String GCP_COMPUTE_ENGINE = "gcp_compute_engine";
 
     /** Google Cloud Run. */
-    public static final String GCP_CLOUD_RUN = "gcp_cloud_run";
+    @Deprecated public static final String GCP_CLOUD_RUN = "gcp_cloud_run";
 
     /** Google Cloud Kubernetes Engine (GKE). */
-    public static final String GCP_KUBERNETES_ENGINE = "gcp_kubernetes_engine";
+    @Deprecated public static final String GCP_KUBERNETES_ENGINE = "gcp_kubernetes_engine";
 
     /** Google Cloud Functions (GCF). */
-    public static final String GCP_CLOUD_FUNCTIONS = "gcp_cloud_functions";
+    @Deprecated public static final String GCP_CLOUD_FUNCTIONS = "gcp_cloud_functions";
 
     /** Google Cloud App Engine (GAE). */
-    public static final String GCP_APP_ENGINE = "gcp_app_engine";
+    @Deprecated public static final String GCP_APP_ENGINE = "gcp_app_engine";
 
     /** Red Hat OpenShift on Google Cloud. */
-    public static final String GCP_OPENSHIFT = "gcp_openshift";
+    @Deprecated public static final String GCP_OPENSHIFT = "gcp_openshift";
 
     /** Red Hat OpenShift on IBM Cloud. */
-    public static final String IBM_CLOUD_OPENSHIFT = "ibm_cloud_openshift";
+    @Deprecated public static final String IBM_CLOUD_OPENSHIFT = "ibm_cloud_openshift";
 
     /** Tencent Cloud Cloud Virtual Machine (CVM). */
-    public static final String TENCENT_CLOUD_CVM = "tencent_cloud_cvm";
+    @Deprecated public static final String TENCENT_CLOUD_CVM = "tencent_cloud_cvm";
 
     /** Tencent Cloud Elastic Kubernetes Service (EKS). */
-    public static final String TENCENT_CLOUD_EKS = "tencent_cloud_eks";
+    @Deprecated public static final String TENCENT_CLOUD_EKS = "tencent_cloud_eks";
 
     /** Tencent Cloud Serverless Cloud Function (SCF). */
-    public static final String TENCENT_CLOUD_SCF = "tencent_cloud_scf";
+    @Deprecated public static final String TENCENT_CLOUD_SCF = "tencent_cloud_scf";
 
     private CloudPlatformValues() {}
   }
 
+  @Deprecated
   public static final class CloudProviderValues {
     /** Alibaba Cloud. */
-    public static final String ALIBABA_CLOUD = "alibaba_cloud";
+    @Deprecated public static final String ALIBABA_CLOUD = "alibaba_cloud";
 
     /** Amazon Web Services. */
-    public static final String AWS = "aws";
+    @Deprecated public static final String AWS = "aws";
 
     /** Microsoft Azure. */
-    public static final String AZURE = "azure";
+    @Deprecated public static final String AZURE = "azure";
 
     /** Google Cloud Platform. */
-    public static final String GCP = "gcp";
+    @Deprecated public static final String GCP = "gcp";
 
     /** Heroku Platform as a Service. */
-    public static final String HEROKU = "heroku";
+    @Deprecated public static final String HEROKU = "heroku";
 
     /** IBM Cloud. */
-    public static final String IBM_CLOUD = "ibm_cloud";
+    @Deprecated public static final String IBM_CLOUD = "ibm_cloud";
 
     /** Tencent Cloud. */
-    public static final String TENCENT_CLOUD = "tencent_cloud";
+    @Deprecated public static final String TENCENT_CLOUD = "tencent_cloud";
 
     private CloudProviderValues() {}
   }
 
+  @Deprecated
   public static final class AwsEcsLaunchtypeValues {
     /** ec2. */
-    public static final String EC2 = "ec2";
+    @Deprecated public static final String EC2 = "ec2";
 
     /** fargate. */
-    public static final String FARGATE = "fargate";
+    @Deprecated public static final String FARGATE = "fargate";
 
     private AwsEcsLaunchtypeValues() {}
   }
 
+  @Deprecated
   public static final class HostArchValues {
     /** AMD64. */
-    public static final String AMD64 = "amd64";
+    @Deprecated public static final String AMD64 = "amd64";
 
     /** ARM32. */
-    public static final String ARM32 = "arm32";
+    @Deprecated public static final String ARM32 = "arm32";
 
     /** ARM64. */
-    public static final String ARM64 = "arm64";
+    @Deprecated public static final String ARM64 = "arm64";
 
     /** Itanium. */
-    public static final String IA64 = "ia64";
+    @Deprecated public static final String IA64 = "ia64";
 
     /** 32-bit PowerPC. */
-    public static final String PPC32 = "ppc32";
+    @Deprecated public static final String PPC32 = "ppc32";
 
     /** 64-bit PowerPC. */
-    public static final String PPC64 = "ppc64";
+    @Deprecated public static final String PPC64 = "ppc64";
 
     /** IBM z/Architecture. */
-    public static final String S390X = "s390x";
+    @Deprecated public static final String S390X = "s390x";
 
     /** 32-bit x86. */
-    public static final String X86 = "x86";
+    @Deprecated public static final String X86 = "x86";
 
     private HostArchValues() {}
   }
 
+  @Deprecated
   public static final class OsTypeValues {
     /** Microsoft Windows. */
-    public static final String WINDOWS = "windows";
+    @Deprecated public static final String WINDOWS = "windows";
 
     /** Linux. */
-    public static final String LINUX = "linux";
+    @Deprecated public static final String LINUX = "linux";
 
     /** Apple Darwin. */
-    public static final String DARWIN = "darwin";
+    @Deprecated public static final String DARWIN = "darwin";
 
     /** FreeBSD. */
-    public static final String FREEBSD = "freebsd";
+    @Deprecated public static final String FREEBSD = "freebsd";
 
     /** NetBSD. */
-    public static final String NETBSD = "netbsd";
+    @Deprecated public static final String NETBSD = "netbsd";
 
     /** OpenBSD. */
-    public static final String OPENBSD = "openbsd";
+    @Deprecated public static final String OPENBSD = "openbsd";
 
     /** DragonFly BSD. */
-    public static final String DRAGONFLYBSD = "dragonflybsd";
+    @Deprecated public static final String DRAGONFLYBSD = "dragonflybsd";
 
     /** HP-UX (Hewlett Packard Unix). */
-    public static final String HPUX = "hpux";
+    @Deprecated public static final String HPUX = "hpux";
 
     /** AIX (Advanced Interactive eXecutive). */
-    public static final String AIX = "aix";
+    @Deprecated public static final String AIX = "aix";
 
     /** SunOS, Oracle Solaris. */
-    public static final String SOLARIS = "solaris";
+    @Deprecated public static final String SOLARIS = "solaris";
 
     /** IBM z/OS. */
-    public static final String Z_OS = "z_os";
+    @Deprecated public static final String Z_OS = "z_os";
 
     private OsTypeValues() {}
   }
 
+  @Deprecated
   public static final class TelemetrySdkLanguageValues {
     /** cpp. */
-    public static final String CPP = "cpp";
+    @Deprecated public static final String CPP = "cpp";
 
     /** dotnet. */
-    public static final String DOTNET = "dotnet";
+    @Deprecated public static final String DOTNET = "dotnet";
 
     /** erlang. */
-    public static final String ERLANG = "erlang";
+    @Deprecated public static final String ERLANG = "erlang";
 
     /** go. */
-    public static final String GO = "go";
+    @Deprecated public static final String GO = "go";
 
     /** java. */
-    public static final String JAVA = "java";
+    @Deprecated public static final String JAVA = "java";
 
     /** nodejs. */
-    public static final String NODEJS = "nodejs";
+    @Deprecated public static final String NODEJS = "nodejs";
 
     /** php. */
-    public static final String PHP = "php";
+    @Deprecated public static final String PHP = "php";
 
     /** python. */
-    public static final String PYTHON = "python";
+    @Deprecated public static final String PYTHON = "python";
 
     /** ruby. */
-    public static final String RUBY = "ruby";
+    @Deprecated public static final String RUBY = "ruby";
 
     /** rust. */
-    public static final String RUST = "rust";
+    @Deprecated public static final String RUST = "rust";
 
     /** swift. */
-    public static final String SWIFT = "swift";
+    @Deprecated public static final String SWIFT = "swift";
 
     /** webjs. */
-    public static final String WEBJS = "webjs";
+    @Deprecated public static final String WEBJS = "webjs";
 
     private TelemetrySdkLanguageValues() {}
   }

--- a/semconv/src/main/java/io/opentelemetry/semconv/ResourceAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/ResourceAttributes.java
@@ -1,0 +1,1245 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.semconv;
+
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.semconv.AttributeKeyTemplate.stringKeyTemplate;
+
+import io.opentelemetry.api.common.AttributeKey;
+import java.util.List;
+
+/**
+ * @deprecated This class is deprecated and will be removed in a future release. It is only provided as a
+ * convenience to help migration to the new semantic conventions classes structure that was introduced
+ * in version 1.24.0.
+ */
+@Deprecated
+@SuppressWarnings("unused")
+public final class ResourceAttributes {
+  /** The URL of the OpenTelemetry schema for these keys and values. */
+  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.23.1";
+
+  /** The cloud account ID the resource is assigned to. */
+  public static final AttributeKey<String> CLOUD_ACCOUNT_ID = stringKey("cloud.account.id");
+
+  /**
+   * Cloud regions often have multiple, isolated locations known as zones to increase availability.
+   * Availability zone represents the zone where the resource is running.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Availability zones are called &quot;zones&quot; on Alibaba Cloud and Google Cloud.
+   * </ul>
+   */
+  public static final AttributeKey<String> CLOUD_AVAILABILITY_ZONE =
+      stringKey("cloud.availability_zone");
+
+  /**
+   * The cloud platform in use.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The prefix of the service SHOULD match the one specified in {@code cloud.provider}.
+   * </ul>
+   */
+  public static final AttributeKey<String> CLOUD_PLATFORM = stringKey("cloud.platform");
+
+  /** Name of the cloud provider. */
+  public static final AttributeKey<String> CLOUD_PROVIDER = stringKey("cloud.provider");
+
+  /**
+   * The geographical region the resource is running.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Refer to your provider's docs to see the available regions, for example <a
+   *       href="https://www.alibabacloud.com/help/doc-detail/40654.htm">Alibaba Cloud regions</a>,
+   *       <a href="https://aws.amazon.com/about-aws/global-infrastructure/regions_az/">AWS
+   *       regions</a>, <a
+   *       href="https://azure.microsoft.com/global-infrastructure/geographies/">Azure regions</a>,
+   *       <a href="https://cloud.google.com/about/locations">Google Cloud regions</a>, or <a
+   *       href="https://www.tencentcloud.com/document/product/213/6091">Tencent Cloud regions</a>.
+   * </ul>
+   */
+  public static final AttributeKey<String> CLOUD_REGION = stringKey("cloud.region");
+
+  /**
+   * Cloud provider-specific native identifier of the monitored cloud resource (e.g. an <a
+   * href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">ARN</a> on
+   * AWS, a <a href="https://learn.microsoft.com/rest/api/resources/resources/get-by-id">fully
+   * qualified resource ID</a> on Azure, a <a
+   * href="https://cloud.google.com/apis/design/resource_names#full_resource_name">full resource
+   * name</a> on GCP)
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>On some cloud providers, it may not be possible to determine the full ID at startup, so
+   *       it may be necessary to set {@code cloud.resource_id} as a span attribute instead.
+   *   <li>The exact value to use for {@code cloud.resource_id} depends on the cloud provider. The
+   *       following well-known definitions MUST be used if you set this attribute and they apply:
+   *   <li><strong>AWS Lambda:</strong> The function <a
+   *       href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">ARN</a>.
+   *       Take care not to use the &quot;invoked ARN&quot; directly but replace any <a
+   *       href="https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html">alias
+   *       suffix</a> with the resolved function version, as the same runtime instance may be
+   *       invokable with multiple different aliases.
+   *   <li><strong>GCP:</strong> The <a
+   *       href="https://cloud.google.com/iam/docs/full-resource-names">URI of the resource</a>
+   *   <li><strong>Azure:</strong> The <a
+   *       href="https://docs.microsoft.com/rest/api/resources/resources/get-by-id">Fully Qualified
+   *       Resource ID</a> of the invoked function, <em>not</em> the function app, having the form
+   *       {@code
+   *       /subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>}.
+   *       This means that a span attribute MUST be used, as an Azure function app can host multiple
+   *       functions that would usually share a TracerProvider.
+   * </ul>
+   */
+  public static final AttributeKey<String> CLOUD_RESOURCE_ID = stringKey("cloud.resource_id");
+
+  /**
+   * The command used to run the container (i.e. the command name).
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>If using embedded credentials or sensitive data, it is recommended to remove them to
+   *       prevent potential leakage.
+   * </ul>
+   */
+  public static final AttributeKey<String> CONTAINER_COMMAND = stringKey("container.command");
+
+  /**
+   * All the command arguments (including the command/executable itself) run by the container. [2]
+   */
+  public static final AttributeKey<List<String>> CONTAINER_COMMAND_ARGS =
+      stringArrayKey("container.command_args");
+
+  /** The full command run by the container as a single string representing the full command. [2] */
+  public static final AttributeKey<String> CONTAINER_COMMAND_LINE =
+      stringKey("container.command_line");
+
+  /**
+   * Container ID. Usually a UUID, as for example used to <a
+   * href="https://docs.docker.com/engine/reference/run/#container-identification">identify Docker
+   * containers</a>. The UUID might be abbreviated.
+   */
+  public static final AttributeKey<String> CONTAINER_ID = stringKey("container.id");
+
+  /**
+   * Runtime specific image identifier. Usually a hash algorithm followed by a UUID.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Docker defines a sha256 of the image id; {@code container.image.id} corresponds to the
+   *       {@code Image} field from the Docker container inspect <a
+   *       href="https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerInspect">API</a>
+   *       endpoint. K8s defines a link to the container registry repository with digest {@code
+   *       "imageID": "registry.azurecr.io
+   *       /namespace/service/dockerfile@sha256:bdeabd40c3a8a492eaf9e8e44d0ebbb84bac7ee25ac0cf8a7159d25f62555625"}.
+   *       The ID is assinged by the container runtime and can vary in different environments.
+   *       Consider using {@code oci.manifest.digest} if it is important to identify the same image
+   *       in different environments/runtimes.
+   * </ul>
+   */
+  public static final AttributeKey<String> CONTAINER_IMAGE_ID = stringKey("container.image.id");
+
+  /** Name of the image the container was built on. */
+  public static final AttributeKey<String> CONTAINER_IMAGE_NAME = stringKey("container.image.name");
+
+  /**
+   * Repo digests of the container image as provided by the container runtime.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li><a
+   *       href="https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect">Docker</a>
+   *       and <a
+   *       href="https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238">CRI</a>
+   *       report those under the {@code RepoDigests} field.
+   * </ul>
+   */
+  public static final AttributeKey<List<String>> CONTAINER_IMAGE_REPO_DIGESTS =
+      stringArrayKey("container.image.repo_digests");
+
+  /**
+   * Container image tags. An example can be found in <a
+   * href="https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect">Docker Image
+   * Inspect</a>. Should be only the {@code <tag>} section of the full name for example from {@code
+   * registry.example.com/my-org/my-image:<tag>}.
+   */
+  public static final AttributeKey<List<String>> CONTAINER_IMAGE_TAGS =
+      stringArrayKey("container.image.tags");
+
+  /** Container name used by container runtime. */
+  public static final AttributeKey<String> CONTAINER_NAME = stringKey("container.name");
+
+  /** The container runtime managing this container. */
+  public static final AttributeKey<String> CONTAINER_RUNTIME = stringKey("container.runtime");
+
+  /**
+   * The digest of the OCI image manifest. For container images specifically is the digest by which
+   * the container image is known.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Follows <a href="https://github.com/opencontainers/image-spec/blob/main/manifest.md">OCI
+   *       Image Manifest Specification</a>, and specifically the <a
+   *       href="https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests">Digest
+   *       property</a>. An example can be found in <a
+   *       href="https://docs.docker.com/registry/spec/manifest-v2-2/#example-image-manifest">Example
+   *       Image Manifest</a>.
+   * </ul>
+   */
+  public static final AttributeKey<String> OCI_MANIFEST_DIGEST = stringKey("oci.manifest.digest");
+
+  /**
+   * Uniquely identifies the framework API revision offered by a version ({@code os.version}) of the
+   * android operating system. More information can be found <a
+   * href="https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels">here</a>.
+   */
+  public static final AttributeKey<String> ANDROID_OS_API_LEVEL = stringKey("android.os.api_level");
+
+  /**
+   * Array of brand name and version separated by a space
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This value is intended to be taken from the <a
+   *       href="https://wicg.github.io/ua-client-hints/#interface">UA client hints API</a> ({@code
+   *       navigator.userAgentData.brands}).
+   * </ul>
+   */
+  public static final AttributeKey<List<String>> BROWSER_BRANDS = stringArrayKey("browser.brands");
+
+  /**
+   * Preferred language of the user using the browser
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This value is intended to be taken from the Navigator API {@code navigator.language}.
+   * </ul>
+   */
+  public static final AttributeKey<String> BROWSER_LANGUAGE = stringKey("browser.language");
+
+  /**
+   * A boolean that is true if the browser is running on a mobile device
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This value is intended to be taken from the <a
+   *       href="https://wicg.github.io/ua-client-hints/#interface">UA client hints API</a> ({@code
+   *       navigator.userAgentData.mobile}). If unavailable, this attribute SHOULD be left unset.
+   * </ul>
+   */
+  public static final AttributeKey<Boolean> BROWSER_MOBILE = booleanKey("browser.mobile");
+
+  /**
+   * The platform on which the browser is running
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This value is intended to be taken from the <a
+   *       href="https://wicg.github.io/ua-client-hints/#interface">UA client hints API</a> ({@code
+   *       navigator.userAgentData.platform}). If unavailable, the legacy {@code navigator.platform}
+   *       API SHOULD NOT be used instead and this attribute SHOULD be left unset in order for the
+   *       values to be consistent. The list of possible values is defined in the <a
+   *       href="https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform">W3C User-Agent Client
+   *       Hints specification</a>. Note that some (but not all) of these values can overlap with
+   *       values in the <a href="./os.md">{@code os.type} and {@code os.name} attributes</a>.
+   *       However, for consistency, the values in the {@code browser.platform} attribute should
+   *       capture the exact value that the user agent provides.
+   * </ul>
+   */
+  public static final AttributeKey<String> BROWSER_PLATFORM = stringKey("browser.platform");
+
+  /**
+   * The ARN of an <a
+   * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html">ECS
+   * cluster</a>.
+   */
+  public static final AttributeKey<String> AWS_ECS_CLUSTER_ARN = stringKey("aws.ecs.cluster.arn");
+
+  /**
+   * The Amazon Resource Name (ARN) of an <a
+   * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html">ECS
+   * container instance</a>.
+   */
+  public static final AttributeKey<String> AWS_ECS_CONTAINER_ARN =
+      stringKey("aws.ecs.container.arn");
+
+  /**
+   * The <a
+   * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html">launch
+   * type</a> for an ECS task.
+   */
+  public static final AttributeKey<String> AWS_ECS_LAUNCHTYPE = stringKey("aws.ecs.launchtype");
+
+  /**
+   * The ARN of an <a
+   * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html">ECS
+   * task definition</a>.
+   */
+  public static final AttributeKey<String> AWS_ECS_TASK_ARN = stringKey("aws.ecs.task.arn");
+
+  /** The task definition family this task definition is a member of. */
+  public static final AttributeKey<String> AWS_ECS_TASK_FAMILY = stringKey("aws.ecs.task.family");
+
+  /** The revision for this task definition. */
+  public static final AttributeKey<String> AWS_ECS_TASK_REVISION =
+      stringKey("aws.ecs.task.revision");
+
+  /** The ARN of an EKS cluster. */
+  public static final AttributeKey<String> AWS_EKS_CLUSTER_ARN = stringKey("aws.eks.cluster.arn");
+
+  /**
+   * The Amazon Resource Name(s) (ARN) of the AWS log group(s).
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>See the <a
+   *       href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format">log
+   *       group ARN format documentation</a>.
+   * </ul>
+   */
+  public static final AttributeKey<List<String>> AWS_LOG_GROUP_ARNS =
+      stringArrayKey("aws.log.group.arns");
+
+  /**
+   * The name(s) of the AWS log group(s) an application is writing to.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Multiple log groups must be supported for cases like multi-container applications, where
+   *       a single application has sidecar containers, and each write to their own log group.
+   * </ul>
+   */
+  public static final AttributeKey<List<String>> AWS_LOG_GROUP_NAMES =
+      stringArrayKey("aws.log.group.names");
+
+  /**
+   * The ARN(s) of the AWS log stream(s).
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>See the <a
+   *       href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format">log
+   *       stream ARN format documentation</a>. One log group can contain several log streams, so
+   *       these ARNs necessarily identify both a log group and a log stream.
+   * </ul>
+   */
+  public static final AttributeKey<List<String>> AWS_LOG_STREAM_ARNS =
+      stringArrayKey("aws.log.stream.arns");
+
+  /** The name(s) of the AWS log stream(s) an application is writing to. */
+  public static final AttributeKey<List<String>> AWS_LOG_STREAM_NAMES =
+      stringArrayKey("aws.log.stream.names");
+
+  /**
+   * The name of the Cloud Run <a
+   * href="https://cloud.google.com/run/docs/managing/job-executions">execution</a> being run for
+   * the Job, as set by the <a
+   * href="https://cloud.google.com/run/docs/container-contract#jobs-env-vars">{@code
+   * CLOUD_RUN_EXECUTION}</a> environment variable.
+   */
+  public static final AttributeKey<String> GCP_CLOUD_RUN_JOB_EXECUTION =
+      stringKey("gcp.cloud_run.job.execution");
+
+  /**
+   * The index for a task within an execution as provided by the <a
+   * href="https://cloud.google.com/run/docs/container-contract#jobs-env-vars">{@code
+   * CLOUD_RUN_TASK_INDEX}</a> environment variable.
+   */
+  public static final AttributeKey<Long> GCP_CLOUD_RUN_JOB_TASK_INDEX =
+      longKey("gcp.cloud_run.job.task_index");
+
+  /**
+   * The hostname of a GCE instance. This is the full value of the default or <a
+   * href="https://cloud.google.com/compute/docs/instances/custom-hostname-vm">custom hostname</a>.
+   */
+  public static final AttributeKey<String> GCP_GCE_INSTANCE_HOSTNAME =
+      stringKey("gcp.gce.instance.hostname");
+
+  /**
+   * The instance name of a GCE instance. This is the value provided by {@code host.name}, the
+   * visible name of the instance in the Cloud Console UI, and the prefix for the default hostname
+   * of the instance as defined by the <a
+   * href="https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names">default
+   * internal DNS name</a>.
+   */
+  public static final AttributeKey<String> GCP_GCE_INSTANCE_NAME =
+      stringKey("gcp.gce.instance.name");
+
+  /** Unique identifier for the application */
+  public static final AttributeKey<String> HEROKU_APP_ID = stringKey("heroku.app.id");
+
+  /** Commit hash for the current release */
+  public static final AttributeKey<String> HEROKU_RELEASE_COMMIT =
+      stringKey("heroku.release.commit");
+
+  /** Time and date the release was created */
+  public static final AttributeKey<String> HEROKU_RELEASE_CREATION_TIMESTAMP =
+      stringKey("heroku.release.creation_timestamp");
+
+  /**
+   * Name of the <a href="https://wikipedia.org/wiki/Deployment_environment">deployment
+   * environment</a> (aka deployment tier).
+   */
+  public static final AttributeKey<String> DEPLOYMENT_ENVIRONMENT =
+      stringKey("deployment.environment");
+
+  /**
+   * A unique identifier representing the device
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The device identifier MUST only be defined using the values outlined below. This value is
+   *       not an advertising identifier and MUST NOT be used as such. On iOS (Swift or
+   *       Objective-C), this value MUST be equal to the <a
+   *       href="https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor">vendor
+   *       identifier</a>. On Android (Java or Kotlin), this value MUST be equal to the Firebase
+   *       Installation ID or a globally unique UUID which is persisted across sessions in your
+   *       application. More information can be found <a
+   *       href="https://developer.android.com/training/articles/user-data-ids">here</a> on best
+   *       practices and exact implementation details. Caution should be taken when storing personal
+   *       data or anything which can identify a user. GDPR and data protection laws may apply,
+   *       ensure you do your own due diligence.
+   * </ul>
+   */
+  public static final AttributeKey<String> DEVICE_ID = stringKey("device.id");
+
+  /**
+   * The name of the device manufacturer
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The Android OS provides this field via <a
+   *       href="https://developer.android.com/reference/android/os/Build#MANUFACTURER">Build</a>.
+   *       iOS apps SHOULD hardcode the value {@code Apple}.
+   * </ul>
+   */
+  public static final AttributeKey<String> DEVICE_MANUFACTURER = stringKey("device.manufacturer");
+
+  /**
+   * The model identifier for the device
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>It's recommended this value represents a machine readable version of the model identifier
+   *       rather than the market or consumer-friendly name of the device.
+   * </ul>
+   */
+  public static final AttributeKey<String> DEVICE_MODEL_IDENTIFIER =
+      stringKey("device.model.identifier");
+
+  /**
+   * The marketing name for the device model
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>It's recommended this value represents a human readable version of the device model
+   *       rather than a machine readable alternative.
+   * </ul>
+   */
+  public static final AttributeKey<String> DEVICE_MODEL_NAME = stringKey("device.model.name");
+
+  /**
+   * The execution environment ID as a string, that will be potentially reused for other invocations
+   * to the same function/function version.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li><strong>AWS Lambda:</strong> Use the (full) log stream name.
+   * </ul>
+   */
+  public static final AttributeKey<String> FAAS_INSTANCE = stringKey("faas.instance");
+
+  /**
+   * The amount of memory available to the serverless function converted to Bytes.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>It's recommended to set this attribute since e.g. too little memory can easily stop a
+   *       Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable
+   *       {@code AWS_LAMBDA_FUNCTION_MEMORY_SIZE} provides this information (which must be
+   *       multiplied by 1,048,576).
+   * </ul>
+   */
+  public static final AttributeKey<Long> FAAS_MAX_MEMORY = longKey("faas.max_memory");
+
+  /**
+   * The name of the single function that this runtime instance executes.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This is the name of the function as configured/deployed on the FaaS platform and is
+   *       usually different from the name of the callback function (which may be stored in the <a
+   *       href="/docs/general/attributes.md#source-code-attributes">{@code code.namespace}/{@code
+   *       code.function}</a> span attributes).
+   *   <li>For some cloud providers, the above definition is ambiguous. The following definition of
+   *       function name MUST be used for this attribute (and consequently the span name) for the
+   *       listed cloud providers/products:
+   *   <li><strong>Azure:</strong> The full name {@code <FUNCAPP>/<FUNC>}, i.e., function app name
+   *       followed by a forward slash followed by the function name (this form can also be seen in
+   *       the resource JSON for the function). This means that a span attribute MUST be used, as an
+   *       Azure function app can host multiple functions that would usually share a TracerProvider
+   *       (see also the {@code cloud.resource_id} attribute).
+   * </ul>
+   */
+  public static final AttributeKey<String> FAAS_NAME = stringKey("faas.name");
+
+  /**
+   * The immutable version of the function being executed.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Depending on the cloud provider and platform, use:
+   *   <li><strong>AWS Lambda:</strong> The <a
+   *       href="https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html">function
+   *       version</a> (an integer represented as a decimal string).
+   *   <li><strong>Google Cloud Run (Services):</strong> The <a
+   *       href="https://cloud.google.com/run/docs/managing/revisions">revision</a> (i.e., the
+   *       function name plus the revision suffix).
+   *   <li><strong>Google Cloud Functions:</strong> The value of the <a
+   *       href="https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically">{@code
+   *       K_REVISION} environment variable</a>.
+   *   <li><strong>Azure Functions:</strong> Not applicable. Do not set this attribute.
+   * </ul>
+   */
+  public static final AttributeKey<String> FAAS_VERSION = stringKey("faas.version");
+
+  /** The CPU architecture the host system is running on. */
+  public static final AttributeKey<String> HOST_ARCH = stringKey("host.arch");
+
+  /**
+   * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For
+   * non-containerized systems, this should be the {@code machine-id}. See the table below for the
+   * sources to use to determine the {@code machine-id} based on operating system.
+   */
+  public static final AttributeKey<String> HOST_ID = stringKey("host.id");
+
+  /** VM image ID or host OS image ID. For Cloud, this value is from the provider. */
+  public static final AttributeKey<String> HOST_IMAGE_ID = stringKey("host.image.id");
+
+  /** Name of the VM image or OS install the host was instantiated from. */
+  public static final AttributeKey<String> HOST_IMAGE_NAME = stringKey("host.image.name");
+
+  /**
+   * The version string of the VM image or host OS as defined in <a
+   * href="README.md#version-attributes">Version Attributes</a>.
+   */
+  public static final AttributeKey<String> HOST_IMAGE_VERSION = stringKey("host.image.version");
+
+  /**
+   * Available IP addresses of the host, excluding loopback interfaces.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>IPv4 Addresses MUST be specified in dotted-quad notation. IPv6 addresses MUST be
+   *       specified in the <a href="https://www.rfc-editor.org/rfc/rfc5952.html">RFC 5952</a>
+   *       format.
+   * </ul>
+   */
+  public static final AttributeKey<List<String>> HOST_IP = stringArrayKey("host.ip");
+
+  /**
+   * Available MAC addresses of the host, excluding loopback interfaces.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>MAC Addresses MUST be represented in <a
+   *       href="https://standards.ieee.org/wp-content/uploads/import/documents/tutorials/eui.pdf">IEEE
+   *       RA hexadecimal form</a>: as hyphen-separated octets in uppercase hexadecimal form from
+   *       most to least significant.
+   * </ul>
+   */
+  public static final AttributeKey<List<String>> HOST_MAC = stringArrayKey("host.mac");
+
+  /**
+   * Name of the host. On Unix systems, it may contain what the hostname command returns, or the
+   * fully qualified hostname, or another name specified by the user.
+   */
+  public static final AttributeKey<String> HOST_NAME = stringKey("host.name");
+
+  /** Type of host. For Cloud, this must be the machine type. */
+  public static final AttributeKey<String> HOST_TYPE = stringKey("host.type");
+
+  /** The amount of level 2 memory cache available to the processor (in Bytes). */
+  public static final AttributeKey<Long> HOST_CPU_CACHE_L2_SIZE = longKey("host.cpu.cache.l2.size");
+
+  /** Numeric value specifying the family or generation of the CPU. */
+  public static final AttributeKey<Long> HOST_CPU_FAMILY = longKey("host.cpu.family");
+
+  /**
+   * Model identifier. It provides more granular information about the CPU, distinguishing it from
+   * other CPUs within the same family.
+   */
+  public static final AttributeKey<Long> HOST_CPU_MODEL_ID = longKey("host.cpu.model.id");
+
+  /** Model designation of the processor. */
+  public static final AttributeKey<String> HOST_CPU_MODEL_NAME = stringKey("host.cpu.model.name");
+
+  /** Stepping or core revisions. */
+  public static final AttributeKey<Long> HOST_CPU_STEPPING = longKey("host.cpu.stepping");
+
+  /**
+   * Processor manufacturer identifier. A maximum 12-character string.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li><a href="https://wiki.osdev.org/CPUID">CPUID</a> command returns the vendor ID string in
+   *       EBX, EDX and ECX registers. Writing these to memory in this order results in a
+   *       12-character string.
+   * </ul>
+   */
+  public static final AttributeKey<String> HOST_CPU_VENDOR_ID = stringKey("host.cpu.vendor.id");
+
+  /** The name of the cluster. */
+  public static final AttributeKey<String> K8S_CLUSTER_NAME = stringKey("k8s.cluster.name");
+
+  /**
+   * A pseudo-ID for the cluster, set to the UID of the {@code kube-system} namespace.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>K8s doesn't have support for obtaining a cluster ID. If this is ever added, we will
+   *       recommend collecting the {@code k8s.cluster.uid} through the official APIs. In the
+   *       meantime, we are able to use the {@code uid} of the {@code kube-system} namespace as a
+   *       proxy for cluster ID. Read on for the rationale.
+   *   <li>Every object created in a K8s cluster is assigned a distinct UID. The {@code kube-system}
+   *       namespace is used by Kubernetes itself and will exist for the lifetime of the cluster.
+   *       Using the {@code uid} of the {@code kube-system} namespace is a reasonable proxy for the
+   *       K8s ClusterID as it will only change if the cluster is rebuilt. Furthermore, Kubernetes
+   *       UIDs are UUIDs as standardized by <a
+   *       href="https://www.itu.int/ITU-T/studygroups/com17/oid.html">ISO/IEC 9834-8 and ITU-T
+   *       X.667</a>. Which states:
+   *   <li>If generated according to one of the mechanisms defined in Rec. ITU-T X.667 | ISO/IEC
+   *       9834-8, a UUID is either guaranteed to be different from all other UUIDs generated before
+   *       3603 A.D., or is extremely likely to be different (depending on the mechanism chosen).
+   *   <li>Therefore, UIDs between clusters should be extremely unlikely to conflict.
+   * </ul>
+   */
+  public static final AttributeKey<String> K8S_CLUSTER_UID = stringKey("k8s.cluster.uid");
+
+  /** The name of the Node. */
+  public static final AttributeKey<String> K8S_NODE_NAME = stringKey("k8s.node.name");
+
+  /** The UID of the Node. */
+  public static final AttributeKey<String> K8S_NODE_UID = stringKey("k8s.node.uid");
+
+  /** The name of the namespace that the pod is running in. */
+  public static final AttributeKey<String> K8S_NAMESPACE_NAME = stringKey("k8s.namespace.name");
+
+  /** The name of the Pod. */
+  public static final AttributeKey<String> K8S_POD_NAME = stringKey("k8s.pod.name");
+
+  /** The UID of the Pod. */
+  public static final AttributeKey<String> K8S_POD_UID = stringKey("k8s.pod.uid");
+
+  /**
+   * The name of the Container from Pod specification, must be unique within a Pod. Container
+   * runtime usually uses different globally unique name ({@code container.name}).
+   */
+  public static final AttributeKey<String> K8S_CONTAINER_NAME = stringKey("k8s.container.name");
+
+  /**
+   * Number of times the container was restarted. This attribute can be used to identify a
+   * particular container (running or stopped) within a container spec.
+   */
+  public static final AttributeKey<Long> K8S_CONTAINER_RESTART_COUNT =
+      longKey("k8s.container.restart_count");
+
+  /** The name of the ReplicaSet. */
+  public static final AttributeKey<String> K8S_REPLICASET_NAME = stringKey("k8s.replicaset.name");
+
+  /** The UID of the ReplicaSet. */
+  public static final AttributeKey<String> K8S_REPLICASET_UID = stringKey("k8s.replicaset.uid");
+
+  /** The name of the Deployment. */
+  public static final AttributeKey<String> K8S_DEPLOYMENT_NAME = stringKey("k8s.deployment.name");
+
+  /** The UID of the Deployment. */
+  public static final AttributeKey<String> K8S_DEPLOYMENT_UID = stringKey("k8s.deployment.uid");
+
+  /** The name of the StatefulSet. */
+  public static final AttributeKey<String> K8S_STATEFULSET_NAME = stringKey("k8s.statefulset.name");
+
+  /** The UID of the StatefulSet. */
+  public static final AttributeKey<String> K8S_STATEFULSET_UID = stringKey("k8s.statefulset.uid");
+
+  /** The name of the DaemonSet. */
+  public static final AttributeKey<String> K8S_DAEMONSET_NAME = stringKey("k8s.daemonset.name");
+
+  /** The UID of the DaemonSet. */
+  public static final AttributeKey<String> K8S_DAEMONSET_UID = stringKey("k8s.daemonset.uid");
+
+  /** The name of the Job. */
+  public static final AttributeKey<String> K8S_JOB_NAME = stringKey("k8s.job.name");
+
+  /** The UID of the Job. */
+  public static final AttributeKey<String> K8S_JOB_UID = stringKey("k8s.job.uid");
+
+  /** The name of the CronJob. */
+  public static final AttributeKey<String> K8S_CRONJOB_NAME = stringKey("k8s.cronjob.name");
+
+  /** The UID of the CronJob. */
+  public static final AttributeKey<String> K8S_CRONJOB_UID = stringKey("k8s.cronjob.uid");
+
+  /** Unique identifier for a particular build or compilation of the operating system. */
+  public static final AttributeKey<String> OS_BUILD_ID = stringKey("os.build_id");
+
+  /**
+   * Human readable (not intended to be parsed) OS version information, like e.g. reported by {@code
+   * ver} or {@code lsb_release -a} commands.
+   */
+  public static final AttributeKey<String> OS_DESCRIPTION = stringKey("os.description");
+
+  /** Human readable operating system name. */
+  public static final AttributeKey<String> OS_NAME = stringKey("os.name");
+
+  /** The operating system type. */
+  public static final AttributeKey<String> OS_TYPE = stringKey("os.type");
+
+  /**
+   * The version string of the operating system as defined in <a
+   * href="/docs/resource/README.md#version-attributes">Version Attributes</a>.
+   */
+  public static final AttributeKey<String> OS_VERSION = stringKey("os.version");
+
+  /**
+   * The command used to launch the process (i.e. the command name). On Linux based systems, can be
+   * set to the zeroth string in {@code proc/[pid]/cmdline}. On Windows, can be set to the first
+   * parameter extracted from {@code GetCommandLineW}.
+   */
+  public static final AttributeKey<String> PROCESS_COMMAND = stringKey("process.command");
+
+  /**
+   * All the command arguments (including the command/executable itself) as received by the process.
+   * On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according
+   * to the list of null-delimited strings extracted from {@code proc/[pid]/cmdline}. For libc-based
+   * executables, this would be the full argv vector passed to {@code main}.
+   */
+  public static final AttributeKey<List<String>> PROCESS_COMMAND_ARGS =
+      stringArrayKey("process.command_args");
+
+  /**
+   * The full command used to launch the process as a single string representing the full command.
+   * On Windows, can be set to the result of {@code GetCommandLineW}. Do not set this if you have to
+   * assemble it just for monitoring; use {@code process.command_args} instead.
+   */
+  public static final AttributeKey<String> PROCESS_COMMAND_LINE = stringKey("process.command_line");
+
+  /**
+   * The name of the process executable. On Linux based systems, can be set to the {@code Name} in
+   * {@code proc/[pid]/status}. On Windows, can be set to the base name of {@code
+   * GetProcessImageFileNameW}.
+   */
+  public static final AttributeKey<String> PROCESS_EXECUTABLE_NAME =
+      stringKey("process.executable.name");
+
+  /**
+   * The full path to the process executable. On Linux based systems, can be set to the target of
+   * {@code proc/[pid]/exe}. On Windows, can be set to the result of {@code
+   * GetProcessImageFileNameW}.
+   */
+  public static final AttributeKey<String> PROCESS_EXECUTABLE_PATH =
+      stringKey("process.executable.path");
+
+  /** The username of the user that owns the process. */
+  public static final AttributeKey<String> PROCESS_OWNER = stringKey("process.owner");
+
+  /** Parent Process identifier (PID). */
+  public static final AttributeKey<Long> PROCESS_PARENT_PID = longKey("process.parent_pid");
+
+  /** Process identifier (PID). */
+  public static final AttributeKey<Long> PROCESS_PID = longKey("process.pid");
+
+  /**
+   * An additional description about the runtime of the process, for example a specific vendor
+   * customization of the runtime environment.
+   */
+  public static final AttributeKey<String> PROCESS_RUNTIME_DESCRIPTION =
+      stringKey("process.runtime.description");
+
+  /**
+   * The name of the runtime of this process. For compiled native binaries, this SHOULD be the name
+   * of the compiler.
+   */
+  public static final AttributeKey<String> PROCESS_RUNTIME_NAME = stringKey("process.runtime.name");
+
+  /**
+   * The version of the runtime of this process, as returned by the runtime without modification.
+   */
+  public static final AttributeKey<String> PROCESS_RUNTIME_VERSION =
+      stringKey("process.runtime.version");
+
+  /**
+   * Logical name of the service.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>MUST be the same for all instances of horizontally scaled services. If the value was not
+   *       specified, SDKs MUST fallback to {@code unknown_service:} concatenated with <a
+   *       href="process.md#process">{@code process.executable.name}</a>, e.g. {@code
+   *       unknown_service:bash}. If {@code process.executable.name} is not available, the value
+   *       MUST be set to {@code unknown_service}.
+   * </ul>
+   */
+  public static final AttributeKey<String> SERVICE_NAME = stringKey("service.name");
+
+  /**
+   * The version string of the service API or implementation. The format is not defined by these
+   * conventions.
+   */
+  public static final AttributeKey<String> SERVICE_VERSION = stringKey("service.version");
+
+  /**
+   * The string ID of the service instance.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>MUST be unique for each instance of the same {@code service.namespace,service.name} pair
+   *       (in other words {@code service.namespace,service.name,service.instance.id} triplet MUST
+   *       be globally unique). The ID helps to distinguish instances of the same service that exist
+   *       at the same time (e.g. instances of a horizontally scaled service). It is preferable for
+   *       the ID to be persistent and stay the same for the lifetime of the service instance,
+   *       however it is acceptable that the ID is ephemeral and changes during important lifetime
+   *       events for the service (e.g. service restarts). If the service has no inherent unique ID
+   *       that can be used as the value of this attribute it is recommended to generate a random
+   *       Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use
+   *       Version 5, see RFC 4122 for more recommendations).
+   * </ul>
+   */
+  public static final AttributeKey<String> SERVICE_INSTANCE_ID = stringKey("service.instance.id");
+
+  /**
+   * A namespace for {@code service.name}.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>A string value having a meaning that helps to distinguish a group of services, for
+   *       example the team name that owns a group of services. {@code service.name} is expected to
+   *       be unique within the same namespace. If {@code service.namespace} is not specified in the
+   *       Resource then {@code service.name} is expected to be unique for all services that have no
+   *       explicit namespace defined (so the empty/unspecified namespace is simply one more valid
+   *       namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+   * </ul>
+   */
+  public static final AttributeKey<String> SERVICE_NAMESPACE = stringKey("service.namespace");
+
+  /** The language of the telemetry SDK. */
+  public static final AttributeKey<String> TELEMETRY_SDK_LANGUAGE =
+      stringKey("telemetry.sdk.language");
+
+  /**
+   * The name of the telemetry SDK as defined above.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The OpenTelemetry SDK MUST set the {@code telemetry.sdk.name} attribute to {@code
+   *       opentelemetry}. If another SDK, like a fork or a vendor-provided implementation, is used,
+   *       this SDK MUST set the {@code telemetry.sdk.name} attribute to the fully-qualified class
+   *       or module name of this SDK's main entry point or another suitable identifier depending on
+   *       the language. The identifier {@code opentelemetry} is reserved and MUST NOT be used in
+   *       this case. All custom identifiers SHOULD be stable across different versions of an
+   *       implementation.
+   * </ul>
+   */
+  public static final AttributeKey<String> TELEMETRY_SDK_NAME = stringKey("telemetry.sdk.name");
+
+  /** The version string of the telemetry SDK. */
+  public static final AttributeKey<String> TELEMETRY_SDK_VERSION =
+      stringKey("telemetry.sdk.version");
+
+  /**
+   * The name of the auto instrumentation agent or distribution, if used.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Official auto instrumentation agents and distributions SHOULD set the {@code
+   *       telemetry.distro.name} attribute to a string starting with {@code opentelemetry-}, e.g.
+   *       {@code opentelemetry-java-instrumentation}.
+   * </ul>
+   */
+  public static final AttributeKey<String> TELEMETRY_DISTRO_NAME =
+      stringKey("telemetry.distro.name");
+
+  /** The version string of the auto instrumentation agent or distribution, if used. */
+  public static final AttributeKey<String> TELEMETRY_DISTRO_VERSION =
+      stringKey("telemetry.distro.version");
+
+  /** Additional description of the web engine (e.g. detailed version and edition information). */
+  public static final AttributeKey<String> WEBENGINE_DESCRIPTION =
+      stringKey("webengine.description");
+
+  /** The name of the web engine. */
+  public static final AttributeKey<String> WEBENGINE_NAME = stringKey("webengine.name");
+
+  /** The version of the web engine. */
+  public static final AttributeKey<String> WEBENGINE_VERSION = stringKey("webengine.version");
+
+  /** The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP). */
+  public static final AttributeKey<String> OTEL_SCOPE_NAME = stringKey("otel.scope.name");
+
+  /** The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP). */
+  public static final AttributeKey<String> OTEL_SCOPE_VERSION = stringKey("otel.scope.version");
+
+  /**
+   * Deprecated, use the {@code otel.scope.name} attribute.
+   *
+   * @deprecated Deprecated, use the `otel.scope.name` attribute.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_LIBRARY_NAME = stringKey("otel.library.name");
+
+  /**
+   * Deprecated, use the {@code otel.scope.version} attribute.
+   *
+   * @deprecated Deprecated, use the `otel.scope.version` attribute.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_LIBRARY_VERSION = stringKey("otel.library.version");
+
+  /** Container labels, {@code <key>} being the label name, the value being the label value. */
+  public static final AttributeKeyTemplate<String> CONTAINER_LABELS =
+      stringKeyTemplate("container.labels");
+
+  // Enum definitions
+  public static final class CloudPlatformValues {
+    /** Alibaba Cloud Elastic Compute Service. */
+    public static final String ALIBABA_CLOUD_ECS = "alibaba_cloud_ecs";
+
+    /** Alibaba Cloud Function Compute. */
+    public static final String ALIBABA_CLOUD_FC = "alibaba_cloud_fc";
+
+    /** Red Hat OpenShift on Alibaba Cloud. */
+    public static final String ALIBABA_CLOUD_OPENSHIFT = "alibaba_cloud_openshift";
+
+    /** AWS Elastic Compute Cloud. */
+    public static final String AWS_EC2 = "aws_ec2";
+
+    /** AWS Elastic Container Service. */
+    public static final String AWS_ECS = "aws_ecs";
+
+    /** AWS Elastic Kubernetes Service. */
+    public static final String AWS_EKS = "aws_eks";
+
+    /** AWS Lambda. */
+    public static final String AWS_LAMBDA = "aws_lambda";
+
+    /** AWS Elastic Beanstalk. */
+    public static final String AWS_ELASTIC_BEANSTALK = "aws_elastic_beanstalk";
+
+    /** AWS App Runner. */
+    public static final String AWS_APP_RUNNER = "aws_app_runner";
+
+    /** Red Hat OpenShift on AWS (ROSA). */
+    public static final String AWS_OPENSHIFT = "aws_openshift";
+
+    /** Azure Virtual Machines. */
+    public static final String AZURE_VM = "azure_vm";
+
+    /** Azure Container Instances. */
+    public static final String AZURE_CONTAINER_INSTANCES = "azure_container_instances";
+
+    /** Azure Kubernetes Service. */
+    public static final String AZURE_AKS = "azure_aks";
+
+    /** Azure Functions. */
+    public static final String AZURE_FUNCTIONS = "azure_functions";
+
+    /** Azure App Service. */
+    public static final String AZURE_APP_SERVICE = "azure_app_service";
+
+    /** Azure Red Hat OpenShift. */
+    public static final String AZURE_OPENSHIFT = "azure_openshift";
+
+    /** Google Bare Metal Solution (BMS). */
+    public static final String GCP_BARE_METAL_SOLUTION = "gcp_bare_metal_solution";
+
+    /** Google Cloud Compute Engine (GCE). */
+    public static final String GCP_COMPUTE_ENGINE = "gcp_compute_engine";
+
+    /** Google Cloud Run. */
+    public static final String GCP_CLOUD_RUN = "gcp_cloud_run";
+
+    /** Google Cloud Kubernetes Engine (GKE). */
+    public static final String GCP_KUBERNETES_ENGINE = "gcp_kubernetes_engine";
+
+    /** Google Cloud Functions (GCF). */
+    public static final String GCP_CLOUD_FUNCTIONS = "gcp_cloud_functions";
+
+    /** Google Cloud App Engine (GAE). */
+    public static final String GCP_APP_ENGINE = "gcp_app_engine";
+
+    /** Red Hat OpenShift on Google Cloud. */
+    public static final String GCP_OPENSHIFT = "gcp_openshift";
+
+    /** Red Hat OpenShift on IBM Cloud. */
+    public static final String IBM_CLOUD_OPENSHIFT = "ibm_cloud_openshift";
+
+    /** Tencent Cloud Cloud Virtual Machine (CVM). */
+    public static final String TENCENT_CLOUD_CVM = "tencent_cloud_cvm";
+
+    /** Tencent Cloud Elastic Kubernetes Service (EKS). */
+    public static final String TENCENT_CLOUD_EKS = "tencent_cloud_eks";
+
+    /** Tencent Cloud Serverless Cloud Function (SCF). */
+    public static final String TENCENT_CLOUD_SCF = "tencent_cloud_scf";
+
+    private CloudPlatformValues() {}
+  }
+
+  public static final class CloudProviderValues {
+    /** Alibaba Cloud. */
+    public static final String ALIBABA_CLOUD = "alibaba_cloud";
+
+    /** Amazon Web Services. */
+    public static final String AWS = "aws";
+
+    /** Microsoft Azure. */
+    public static final String AZURE = "azure";
+
+    /** Google Cloud Platform. */
+    public static final String GCP = "gcp";
+
+    /** Heroku Platform as a Service. */
+    public static final String HEROKU = "heroku";
+
+    /** IBM Cloud. */
+    public static final String IBM_CLOUD = "ibm_cloud";
+
+    /** Tencent Cloud. */
+    public static final String TENCENT_CLOUD = "tencent_cloud";
+
+    private CloudProviderValues() {}
+  }
+
+  public static final class AwsEcsLaunchtypeValues {
+    /** ec2. */
+    public static final String EC2 = "ec2";
+
+    /** fargate. */
+    public static final String FARGATE = "fargate";
+
+    private AwsEcsLaunchtypeValues() {}
+  }
+
+  public static final class HostArchValues {
+    /** AMD64. */
+    public static final String AMD64 = "amd64";
+
+    /** ARM32. */
+    public static final String ARM32 = "arm32";
+
+    /** ARM64. */
+    public static final String ARM64 = "arm64";
+
+    /** Itanium. */
+    public static final String IA64 = "ia64";
+
+    /** 32-bit PowerPC. */
+    public static final String PPC32 = "ppc32";
+
+    /** 64-bit PowerPC. */
+    public static final String PPC64 = "ppc64";
+
+    /** IBM z/Architecture. */
+    public static final String S390X = "s390x";
+
+    /** 32-bit x86. */
+    public static final String X86 = "x86";
+
+    private HostArchValues() {}
+  }
+
+  public static final class OsTypeValues {
+    /** Microsoft Windows. */
+    public static final String WINDOWS = "windows";
+
+    /** Linux. */
+    public static final String LINUX = "linux";
+
+    /** Apple Darwin. */
+    public static final String DARWIN = "darwin";
+
+    /** FreeBSD. */
+    public static final String FREEBSD = "freebsd";
+
+    /** NetBSD. */
+    public static final String NETBSD = "netbsd";
+
+    /** OpenBSD. */
+    public static final String OPENBSD = "openbsd";
+
+    /** DragonFly BSD. */
+    public static final String DRAGONFLYBSD = "dragonflybsd";
+
+    /** HP-UX (Hewlett Packard Unix). */
+    public static final String HPUX = "hpux";
+
+    /** AIX (Advanced Interactive eXecutive). */
+    public static final String AIX = "aix";
+
+    /** SunOS, Oracle Solaris. */
+    public static final String SOLARIS = "solaris";
+
+    /** IBM z/OS. */
+    public static final String Z_OS = "z_os";
+
+    private OsTypeValues() {}
+  }
+
+  public static final class TelemetrySdkLanguageValues {
+    /** cpp. */
+    public static final String CPP = "cpp";
+
+    /** dotnet. */
+    public static final String DOTNET = "dotnet";
+
+    /** erlang. */
+    public static final String ERLANG = "erlang";
+
+    /** go. */
+    public static final String GO = "go";
+
+    /** java. */
+    public static final String JAVA = "java";
+
+    /** nodejs. */
+    public static final String NODEJS = "nodejs";
+
+    /** php. */
+    public static final String PHP = "php";
+
+    /** python. */
+    public static final String PYTHON = "python";
+
+    /** ruby. */
+    public static final String RUBY = "ruby";
+
+    /** rust. */
+    public static final String RUST = "rust";
+
+    /** swift. */
+    public static final String SWIFT = "swift";
+
+    /** webjs. */
+    public static final String WEBJS = "webjs";
+
+    private TelemetrySdkLanguageValues() {}
+  }
+
+  /**
+   * Red Hat OpenShift on Google Cloud.
+   *
+   * @deprecated This item has been removed as of 1.18.0 of the semantic conventions. Use {@link
+   *     ResourceAttributes#GCP_OPENSHIFT} instead.
+   */
+  @Deprecated public static final String GCP_OPENSHIFT = "gcp_openshift";
+
+  /**
+   * Full user-agent string provided by the browser
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The user-agent value SHOULD be provided only from browsers that do not have a mechanism
+   *       to retrieve brands and platform individually from the User-Agent Client Hints API. To
+   *       retrieve the value, the legacy {@code navigator.userAgent} API can be used.
+   * </ul>
+   *
+   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use
+   *     {@link io.opentelemetry.semconv.SemanticAttributes#USER_AGENT_ORIGINAL} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> BROWSER_USER_AGENT = stringKey("browser.user_agent");
+
+  /**
+   * The unique ID of the single function that this runtime instance executes.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>On some cloud providers, it may not be possible to determine the full ID at startup, so
+   *       consider setting {@code faas.id} as a span attribute instead.
+   *   <li>The exact value to use for {@code faas.id} depends on the cloud provider:
+   *   <li><strong>AWS Lambda:</strong> The function <a
+   *       href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">ARN</a>.
+   *       Take care not to use the &quot;invoked ARN&quot; directly but replace any <a
+   *       href="https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html">alias
+   *       suffix</a> with the resolved function version, as the same runtime instance may be
+   *       invokable with multiple different aliases.
+   *   <li><strong>GCP:</strong> The <a
+   *       href="https://cloud.google.com/iam/docs/full-resource-names">URI of the resource</a>
+   *   <li><strong>Azure:</strong> The <a
+   *       href="https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id">Fully
+   *       Qualified Resource ID</a> of the invoked function, <em>not</em> the function app, having
+   *       the form {@code
+   *       /subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>}.
+   *       This means that a span attribute MUST be used, as an Azure function app can host multiple
+   *       functions that would usually share a TracerProvider.
+   * </ul>
+   *
+   * @deprecated This item has been removed in 1.19.0 version of the semantic conventions. Use
+   *     {@link ResourceAttributes#CLOUD_RESOURCE_ID} instead.
+   */
+  @Deprecated public static final AttributeKey<String> FAAS_ID = stringKey("faas.id");
+
+  /**
+   * The version string of the auto instrumentation agent, if used.
+   *
+   * @deprecated This item has been renamed in 1.22.0 of the semantic conventions. Use {@link
+   *     ResourceAttributes#TELEMETRY_DISTRO_VERSION} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> TELEMETRY_AUTO_VERSION =
+      stringKey("telemetry.auto.version");
+
+  /**
+   * Container image tag.
+   *
+   * @deprecated This item has been renamed in 1.22.0 of the semantic conventions. Use {@link
+   *     ResourceAttributes#CONTAINER_IMAGE_TAGS} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> CONTAINER_IMAGE_TAG = stringKey("container.image.tag");
+
+  private ResourceAttributes() {}
+}

--- a/semconv/src/main/java/io/opentelemetry/semconv/SchemaUrls.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/SchemaUrls.java
@@ -7,6 +7,7 @@ package io.opentelemetry.semconv;
 
 public final class SchemaUrls {
 
+  public static final String V1_25_0 = "https://opentelemetry.io/schemas/1.25.0";
   public static final String V1_24_0 = "https://opentelemetry.io/schemas/1.24.0";
   public static final String V1_23_1 = "https://opentelemetry.io/schemas/1.23.1";
   public static final String V1_22_0 = "https://opentelemetry.io/schemas/1.22.0";

--- a/semconv/src/main/java/io/opentelemetry/semconv/SemanticAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/SemanticAttributes.java
@@ -1,0 +1,3706 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.semconv;
+
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
+import static io.opentelemetry.api.common.AttributeKey.doubleKey;
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.semconv.AttributeKeyTemplate.stringArrayKeyTemplate;
+import static io.opentelemetry.semconv.AttributeKeyTemplate.stringKeyTemplate;
+
+import io.opentelemetry.api.common.AttributeKey;
+import java.util.List;
+
+/**
+ * @deprecated This class is deprecated and will be removed in a future release. It is only provided as a
+ * convenience to help migration to the new semantic conventions classes structure that was introduced
+ * in version 1.24.0.
+ */
+@Deprecated
+@SuppressWarnings("unused")
+public final class SemanticAttributes {
+  /** The URL of the OpenTelemetry schema for these keys and values. */
+  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.23.1";
+
+  /**
+   * Client address - domain name if available without reverse DNS lookup; otherwise, IP address or
+   * Unix domain socket name.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>When observed from the server side, and when communicating through an intermediary,
+   *       {@code client.address} SHOULD represent the client address behind any intermediaries, for
+   *       example proxies, if it's available.
+   * </ul>
+   */
+  public static final AttributeKey<String> CLIENT_ADDRESS = stringKey("client.address");
+
+  /**
+   * Client port number.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>When observed from the server side, and when communicating through an intermediary,
+   *       {@code client.port} SHOULD represent the client port behind any intermediaries, for
+   *       example proxies, if it's available.
+   * </ul>
+   */
+  public static final AttributeKey<Long> CLIENT_PORT = longKey("client.port");
+
+  /**
+   * Destination address - domain name if available without reverse DNS lookup; otherwise, IP
+   * address or Unix domain socket name.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>When observed from the source side, and when communicating through an intermediary,
+   *       {@code destination.address} SHOULD represent the destination address behind any
+   *       intermediaries, for example proxies, if it's available.
+   * </ul>
+   */
+  public static final AttributeKey<String> DESTINATION_ADDRESS = stringKey("destination.address");
+
+  /** Destination port number */
+  public static final AttributeKey<Long> DESTINATION_PORT = longKey("destination.port");
+
+  /**
+   * Describes a class of error the operation ended with.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code error.type} SHOULD be predictable and SHOULD have low cardinality.
+   *       Instrumentations SHOULD document the list of errors they report.
+   *   <li>The cardinality of {@code error.type} within one instrumentation library SHOULD be low.
+   *       Telemetry consumers that aggregate data from multiple instrumentation libraries and
+   *       applications should be prepared for {@code error.type} to have high cardinality at query
+   *       time when no additional filters are applied.
+   *   <li>If the operation has completed successfully, instrumentations SHOULD NOT set {@code
+   *       error.type}.
+   *   <li>If a specific domain defines its own set of error identifiers (such as HTTP or gRPC
+   *       status codes), it's RECOMMENDED to:
+   *   <li>Use a domain-specific attribute
+   *   <li>Set {@code error.type} to capture all errors, regardless of whether they are defined
+   *       within the domain-specific set or not.
+   * </ul>
+   */
+  public static final AttributeKey<String> ERROR_TYPE = stringKey("error.type");
+
+  /** The exception message. */
+  public static final AttributeKey<String> EXCEPTION_MESSAGE = stringKey("exception.message");
+
+  /**
+   * A stacktrace as a string in the natural representation for the language runtime. The
+   * representation is to be determined and documented by each language SIG.
+   */
+  public static final AttributeKey<String> EXCEPTION_STACKTRACE = stringKey("exception.stacktrace");
+
+  /**
+   * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of
+   * the exception should be preferred over the static type in languages that support it.
+   */
+  public static final AttributeKey<String> EXCEPTION_TYPE = stringKey("exception.type");
+
+  /**
+   * The name of the invoked function.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>SHOULD be equal to the {@code faas.name} resource attribute of the invoked function.
+   * </ul>
+   */
+  public static final AttributeKey<String> FAAS_INVOKED_NAME = stringKey("faas.invoked_name");
+
+  /**
+   * The cloud provider of the invoked function.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>SHOULD be equal to the {@code cloud.provider} resource attribute of the invoked function.
+   * </ul>
+   */
+  public static final AttributeKey<String> FAAS_INVOKED_PROVIDER =
+      stringKey("faas.invoked_provider");
+
+  /**
+   * The cloud region of the invoked function.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>SHOULD be equal to the {@code cloud.region} resource attribute of the invoked function.
+   * </ul>
+   */
+  public static final AttributeKey<String> FAAS_INVOKED_REGION = stringKey("faas.invoked_region");
+
+  /** Type of the trigger which caused this function invocation. */
+  public static final AttributeKey<String> FAAS_TRIGGER = stringKey("faas.trigger");
+
+  /**
+   * The <a href="/docs/resource/README.md#service">{@code service.name}</a> of the remote service.
+   * SHOULD be equal to the actual {@code service.name} resource attribute of the remote service if
+   * any.
+   */
+  public static final AttributeKey<String> PEER_SERVICE = stringKey("peer.service");
+
+  /**
+   * Username or client_id extracted from the access token or <a
+   * href="https://tools.ietf.org/html/rfc7235#section-4.2">Authorization</a> header in the inbound
+   * request from outside the system.
+   */
+  public static final AttributeKey<String> ENDUSER_ID = stringKey("enduser.id");
+
+  /**
+   * Actual/assumed role the client is making the request under extracted from token or application
+   * security context.
+   */
+  public static final AttributeKey<String> ENDUSER_ROLE = stringKey("enduser.role");
+
+  /**
+   * Scopes or granted authorities the client currently possesses extracted from token or
+   * application security context. The value would come from the scope associated with an <a
+   * href="https://tools.ietf.org/html/rfc6749#section-3.3">OAuth 2.0 Access Token</a> or an
+   * attribute value in a <a
+   * href="http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html">SAML
+   * 2.0 Assertion</a>.
+   */
+  public static final AttributeKey<String> ENDUSER_SCOPE = stringKey("enduser.scope");
+
+  /**
+   * The domain identifies the business context for the events.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Events across different domains may have same {@code event.name}, yet be unrelated
+   *       events.
+   * </ul>
+   */
+  public static final AttributeKey<String> EVENT_DOMAIN = stringKey("event.domain");
+
+  /** The name identifies the event. */
+  public static final AttributeKey<String> EVENT_NAME = stringKey("event.name");
+
+  /**
+   * A unique identifier for the Log Record.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>If an id is provided, other log records with the same id will be considered duplicates
+   *       and can be removed safely. This means, that two distinguishable log records MUST have
+   *       different values. The id MAY be an <a href="https://github.com/ulid/spec">Universally
+   *       Unique Lexicographically Sortable Identifier (ULID)</a>, but other identifiers (e.g.
+   *       UUID) may be used as needed.
+   * </ul>
+   */
+  public static final AttributeKey<String> LOG_RECORD_UID = stringKey("log.record.uid");
+
+  /** The stream associated with the log. See below for a list of well-known values. */
+  public static final AttributeKey<String> LOG_IOSTREAM = stringKey("log.iostream");
+
+  /** The basename of the file. */
+  public static final AttributeKey<String> LOG_FILE_NAME = stringKey("log.file.name");
+
+  /** The basename of the file, with symlinks resolved. */
+  public static final AttributeKey<String> LOG_FILE_NAME_RESOLVED =
+      stringKey("log.file.name_resolved");
+
+  /** The full path to the file. */
+  public static final AttributeKey<String> LOG_FILE_PATH = stringKey("log.file.path");
+
+  /** The full path to the file, with symlinks resolved. */
+  public static final AttributeKey<String> LOG_FILE_PATH_RESOLVED =
+      stringKey("log.file.path_resolved");
+
+  /**
+   * This attribute represents the state the application has transitioned into at the occurrence of
+   * the event.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The iOS lifecycle states are defined in the <a
+   *       href="https://developer.apple.com/documentation/uikit/uiapplicationdelegate#1656902">UIApplicationDelegate
+   *       documentation</a>, and from which the {@code OS terminology} column values are derived.
+   * </ul>
+   */
+  public static final AttributeKey<String> IOS_STATE = stringKey("ios.state");
+
+  /**
+   * This attribute represents the state the application has transitioned into at the occurrence of
+   * the event.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The Android lifecycle states are defined in <a
+   *       href="https://developer.android.com/guide/components/activities/activity-lifecycle#lc">Activity
+   *       lifecycle callbacks</a>, and from which the {@code OS identifiers} are derived.
+   * </ul>
+   */
+  public static final AttributeKey<String> ANDROID_STATE = stringKey("android.state");
+
+  /**
+   * The name of the connection pool; unique within the instrumented application. In case the
+   * connection pool implementation doesn't provide a name, then the <a
+   * href="/docs/database/database-spans.md#connection-level-attributes">db.connection_string</a>
+   * should be used
+   */
+  public static final AttributeKey<String> POOL_NAME = stringKey("pool.name");
+
+  /** The state of a connection in the pool */
+  public static final AttributeKey<String> STATE = stringKey("state");
+
+  /**
+   * Name of the buffer pool.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Pool names are generally obtained via <a
+   *       href="https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName()">BufferPoolMXBean#getName()</a>.
+   * </ul>
+   */
+  public static final AttributeKey<String> JVM_BUFFER_POOL_NAME = stringKey("jvm.buffer.pool.name");
+
+  /**
+   * Name of the memory pool.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Pool names are generally obtained via <a
+   *       href="https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()">MemoryPoolMXBean#getName()</a>.
+   * </ul>
+   */
+  public static final AttributeKey<String> JVM_MEMORY_POOL_NAME = stringKey("jvm.memory.pool.name");
+
+  /** The type of memory. */
+  public static final AttributeKey<String> JVM_MEMORY_TYPE = stringKey("jvm.memory.type");
+
+  /**
+   * Name of the garbage collector action.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Garbage collector action is generally obtained via <a
+   *       href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()">GarbageCollectionNotificationInfo#getGcAction()</a>.
+   * </ul>
+   */
+  public static final AttributeKey<String> JVM_GC_ACTION = stringKey("jvm.gc.action");
+
+  /**
+   * Name of the garbage collector.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Garbage collector name is generally obtained via <a
+   *       href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcName()">GarbageCollectionNotificationInfo#getGcName()</a>.
+   * </ul>
+   */
+  public static final AttributeKey<String> JVM_GC_NAME = stringKey("jvm.gc.name");
+
+  /** Whether the thread is daemon or not. */
+  public static final AttributeKey<Boolean> JVM_THREAD_DAEMON = booleanKey("jvm.thread.daemon");
+
+  /** State of the thread. */
+  public static final AttributeKey<String> JVM_THREAD_STATE = stringKey("jvm.thread.state");
+
+  /** The device identifier */
+  public static final AttributeKey<String> SYSTEM_DEVICE = stringKey("system.device");
+
+  /** The logical CPU number [0..n-1] */
+  public static final AttributeKey<Long> SYSTEM_CPU_LOGICAL_NUMBER =
+      longKey("system.cpu.logical_number");
+
+  /** The state of the CPU */
+  public static final AttributeKey<String> SYSTEM_CPU_STATE = stringKey("system.cpu.state");
+
+  /** The memory state */
+  public static final AttributeKey<String> SYSTEM_MEMORY_STATE = stringKey("system.memory.state");
+
+  /** The paging access direction */
+  public static final AttributeKey<String> SYSTEM_PAGING_DIRECTION =
+      stringKey("system.paging.direction");
+
+  /** The memory paging state */
+  public static final AttributeKey<String> SYSTEM_PAGING_STATE = stringKey("system.paging.state");
+
+  /** The memory paging type */
+  public static final AttributeKey<String> SYSTEM_PAGING_TYPE = stringKey("system.paging.type");
+
+  /** The disk operation direction */
+  public static final AttributeKey<String> SYSTEM_DISK_DIRECTION =
+      stringKey("system.disk.direction");
+
+  /** The filesystem mode */
+  public static final AttributeKey<String> SYSTEM_FILESYSTEM_MODE =
+      stringKey("system.filesystem.mode");
+
+  /** The filesystem mount path */
+  public static final AttributeKey<String> SYSTEM_FILESYSTEM_MOUNTPOINT =
+      stringKey("system.filesystem.mountpoint");
+
+  /** The filesystem state */
+  public static final AttributeKey<String> SYSTEM_FILESYSTEM_STATE =
+      stringKey("system.filesystem.state");
+
+  /** The filesystem type */
+  public static final AttributeKey<String> SYSTEM_FILESYSTEM_TYPE =
+      stringKey("system.filesystem.type");
+
+  /** */
+  public static final AttributeKey<String> SYSTEM_NETWORK_DIRECTION =
+      stringKey("system.network.direction");
+
+  /** A stateless protocol MUST NOT set this attribute */
+  public static final AttributeKey<String> SYSTEM_NETWORK_STATE = stringKey("system.network.state");
+
+  /**
+   * The process state, e.g., <a
+   * href="https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES">Linux Process State
+   * Codes</a>
+   */
+  public static final AttributeKey<String> SYSTEM_PROCESSES_STATUS =
+      stringKey("system.processes.status");
+
+  /**
+   * The column number in {@code code.filepath} best representing the operation. It SHOULD point
+   * within the code unit named in {@code code.function}.
+   */
+  public static final AttributeKey<Long> CODE_COLUMN = longKey("code.column");
+
+  /**
+   * The source code file name that identifies the code unit as uniquely as possible (preferably an
+   * absolute file path).
+   */
+  public static final AttributeKey<String> CODE_FILEPATH = stringKey("code.filepath");
+
+  /**
+   * The method or function name, or equivalent (usually rightmost part of the code unit's name).
+   */
+  public static final AttributeKey<String> CODE_FUNCTION = stringKey("code.function");
+
+  /**
+   * The line number in {@code code.filepath} best representing the operation. It SHOULD point
+   * within the code unit named in {@code code.function}.
+   */
+  public static final AttributeKey<Long> CODE_LINENO = longKey("code.lineno");
+
+  /**
+   * The &quot;namespace&quot; within which {@code code.function} is defined. Usually the qualified
+   * class or module name, such that {@code code.namespace} + some separator + {@code code.function}
+   * form a unique identifier for the code unit.
+   */
+  public static final AttributeKey<String> CODE_NAMESPACE = stringKey("code.namespace");
+
+  /**
+   * Deprecated, use {@code http.request.method} instead.
+   *
+   * @deprecated Deprecated, use `http.request.method` instead.
+   */
+  @Deprecated public static final AttributeKey<String> HTTP_METHOD = stringKey("http.method");
+
+  /**
+   * Deprecated, use {@code http.request.header.content-length} instead.
+   *
+   * @deprecated Deprecated, use `http.request.header.content-length` instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> HTTP_REQUEST_CONTENT_LENGTH =
+      longKey("http.request_content_length");
+
+  /**
+   * Deprecated, use {@code http.response.header.content-length} instead.
+   *
+   * @deprecated Deprecated, use `http.response.header.content-length` instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> HTTP_RESPONSE_CONTENT_LENGTH =
+      longKey("http.response_content_length");
+
+  /**
+   * Deprecated, use {@code url.scheme} instead.
+   *
+   * @deprecated Deprecated, use `url.scheme` instead.
+   */
+  @Deprecated public static final AttributeKey<String> HTTP_SCHEME = stringKey("http.scheme");
+
+  /**
+   * Deprecated, use {@code http.response.status_code} instead.
+   *
+   * @deprecated Deprecated, use `http.response.status_code` instead.
+   */
+  @Deprecated public static final AttributeKey<Long> HTTP_STATUS_CODE = longKey("http.status_code");
+
+  /**
+   * Deprecated, use {@code url.path} and {@code url.query} instead.
+   *
+   * @deprecated Deprecated, use `url.path` and `url.query` instead.
+   */
+  @Deprecated public static final AttributeKey<String> HTTP_TARGET = stringKey("http.target");
+
+  /**
+   * Deprecated, use {@code url.full} instead.
+   *
+   * @deprecated Deprecated, use `url.full` instead.
+   */
+  @Deprecated public static final AttributeKey<String> HTTP_URL = stringKey("http.url");
+
+  /**
+   * Deprecated, use {@code server.address}.
+   *
+   * @deprecated Deprecated, use `server.address`.
+   */
+  @Deprecated public static final AttributeKey<String> NET_HOST_NAME = stringKey("net.host.name");
+
+  /**
+   * Deprecated, use {@code server.port}.
+   *
+   * @deprecated Deprecated, use `server.port`.
+   */
+  @Deprecated public static final AttributeKey<Long> NET_HOST_PORT = longKey("net.host.port");
+
+  /**
+   * Deprecated, use {@code server.address} on client spans and {@code client.address} on server
+   * spans.
+   *
+   * @deprecated Deprecated, use `server.address` on client spans and `client.address` on server
+   *     spans.
+   */
+  @Deprecated public static final AttributeKey<String> NET_PEER_NAME = stringKey("net.peer.name");
+
+  /**
+   * Deprecated, use {@code server.port} on client spans and {@code client.port} on server spans.
+   *
+   * @deprecated Deprecated, use `server.port` on client spans and `client.port` on server spans.
+   */
+  @Deprecated public static final AttributeKey<Long> NET_PEER_PORT = longKey("net.peer.port");
+
+  /**
+   * Deprecated, use {@code network.protocol.name}.
+   *
+   * @deprecated Deprecated, use `network.protocol.name`.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_PROTOCOL_NAME = stringKey("net.protocol.name");
+
+  /**
+   * Deprecated, use {@code network.protocol.version}.
+   *
+   * @deprecated Deprecated, use `network.protocol.version`.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_PROTOCOL_VERSION = stringKey("net.protocol.version");
+
+  /**
+   * Deprecated, use {@code network.transport} and {@code network.type}.
+   *
+   * @deprecated Deprecated, use `network.transport` and `network.type`.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_SOCK_FAMILY = stringKey("net.sock.family");
+
+  /**
+   * Deprecated, use {@code network.local.address}.
+   *
+   * @deprecated Deprecated, use `network.local.address`.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_SOCK_HOST_ADDR = stringKey("net.sock.host.addr");
+
+  /**
+   * Deprecated, use {@code network.local.port}.
+   *
+   * @deprecated Deprecated, use `network.local.port`.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> NET_SOCK_HOST_PORT = longKey("net.sock.host.port");
+
+  /**
+   * Deprecated, use {@code network.peer.address}.
+   *
+   * @deprecated Deprecated, use `network.peer.address`.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_SOCK_PEER_ADDR = stringKey("net.sock.peer.addr");
+
+  /**
+   * Deprecated, no replacement at this time.
+   *
+   * @deprecated Deprecated, no replacement at this time.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_SOCK_PEER_NAME = stringKey("net.sock.peer.name");
+
+  /**
+   * Deprecated, use {@code network.peer.port}.
+   *
+   * @deprecated Deprecated, use `network.peer.port`.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> NET_SOCK_PEER_PORT = longKey("net.sock.peer.port");
+
+  /**
+   * Deprecated, use {@code network.transport}.
+   *
+   * @deprecated Deprecated, use `network.transport`.
+   */
+  @Deprecated public static final AttributeKey<String> NET_TRANSPORT = stringKey("net.transport");
+
+  /**
+   * The size of the request payload body in bytes. This is the number of bytes transferred
+   * excluding headers and is often, but not always, present as the <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
+   * header. For requests using transport encoding, this should be the compressed size.
+   */
+  public static final AttributeKey<Long> HTTP_REQUEST_BODY_SIZE = longKey("http.request.body.size");
+
+  /**
+   * HTTP request method.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>HTTP request method value SHOULD be &quot;known&quot; to the instrumentation. By default,
+   *       this convention defines &quot;known&quot; methods as the ones listed in <a
+   *       href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH
+   *       method defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.
+   *   <li>If the HTTP request method is not known to instrumentation, it MUST set the {@code
+   *       http.request.method} attribute to {@code _OTHER}.
+   *   <li>If the HTTP instrumentation could end up converting valid HTTP request methods to {@code
+   *       _OTHER}, then it MUST provide a way to override the list of known HTTP methods. If this
+   *       override is done via environment variable, then the environment variable MUST be named
+   *       OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of
+   *       case-sensitive known HTTP methods (this list MUST be a full override of the default known
+   *       method, it is not a list of known methods in addition to the defaults).
+   *   <li>HTTP method names are case-sensitive and {@code http.request.method} attribute value MUST
+   *       match a known HTTP method name exactly. Instrumentations for specific web frameworks that
+   *       consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+   *       Tracing instrumentations that do so, MUST also set {@code http.request.method_original}
+   *       to the original value.
+   * </ul>
+   */
+  public static final AttributeKey<String> HTTP_REQUEST_METHOD = stringKey("http.request.method");
+
+  /** Original HTTP method sent by the client in the request line. */
+  public static final AttributeKey<String> HTTP_REQUEST_METHOD_ORIGINAL =
+      stringKey("http.request.method_original");
+
+  /**
+   * The ordinal number of request resending attempt (for any reason, including redirects).
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The resend count SHOULD be updated each time an HTTP request gets resent by the client,
+   *       regardless of what was the cause of the resending (e.g. redirection, authorization
+   *       failure, 503 Server Unavailable, network issues, or any other).
+   * </ul>
+   */
+  public static final AttributeKey<Long> HTTP_REQUEST_RESEND_COUNT =
+      longKey("http.request.resend_count");
+
+  /**
+   * The size of the response payload body in bytes. This is the number of bytes transferred
+   * excluding headers and is often, but not always, present as the <a
+   * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
+   * header. For requests using transport encoding, this should be the compressed size.
+   */
+  public static final AttributeKey<Long> HTTP_RESPONSE_BODY_SIZE =
+      longKey("http.response.body.size");
+
+  /** <a href="https://tools.ietf.org/html/rfc7231#section-6">HTTP response status code</a>. */
+  public static final AttributeKey<Long> HTTP_RESPONSE_STATUS_CODE =
+      longKey("http.response.status_code");
+
+  /**
+   * The matched route, that is, the path template in the format used by the respective server
+   * framework.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>MUST NOT be populated when this is not supported by the HTTP server framework as the
+   *       route attribute should have low-cardinality and the URI path can NOT substitute it.
+   *       SHOULD include the <a href="/docs/http/http-spans.md#http-server-definitions">application
+   *       root</a> if there is one.
+   * </ul>
+   */
+  public static final AttributeKey<String> HTTP_ROUTE = stringKey("http.route");
+
+  /**
+   * The number of messages sent, received, or processed in the scope of the batching operation.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Instrumentations SHOULD NOT set {@code messaging.batch.message_count} on spans that
+   *       operate with a single message. When a messaging client library supports both batch and
+   *       single-message API for the same operation, instrumentations SHOULD use {@code
+   *       messaging.batch.message_count} for batching APIs and SHOULD NOT use it for single-message
+   *       APIs.
+   * </ul>
+   */
+  public static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
+      longKey("messaging.batch.message_count");
+
+  /** A unique identifier for the client that consumes or produces a message. */
+  public static final AttributeKey<String> MESSAGING_CLIENT_ID = stringKey("messaging.client_id");
+
+  /**
+   * A boolean that is true if the message destination is anonymous (could be unnamed or have
+   * auto-generated name).
+   */
+  public static final AttributeKey<Boolean> MESSAGING_DESTINATION_ANONYMOUS =
+      booleanKey("messaging.destination.anonymous");
+
+  /**
+   * The message destination name
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Destination name SHOULD uniquely identify a specific queue, topic or other entity within
+   *       the broker. If the broker doesn't have such notion, the destination name SHOULD uniquely
+   *       identify the broker.
+   * </ul>
+   */
+  public static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
+      stringKey("messaging.destination.name");
+
+  /**
+   * Low cardinality representation of the messaging destination name
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Destination names could be constructed from templates. An example would be a destination
+   *       name involving a user name or product id. Although the destination name in this case is
+   *       of high cardinality, the underlying template is of low cardinality and can be effectively
+   *       used for grouping and aggregation.
+   * </ul>
+   */
+  public static final AttributeKey<String> MESSAGING_DESTINATION_TEMPLATE =
+      stringKey("messaging.destination.template");
+
+  /**
+   * A boolean that is true if the message destination is temporary and might not exist anymore
+   * after messages are processed.
+   */
+  public static final AttributeKey<Boolean> MESSAGING_DESTINATION_TEMPORARY =
+      booleanKey("messaging.destination.temporary");
+
+  /**
+   * A boolean that is true if the publish message destination is anonymous (could be unnamed or
+   * have auto-generated name).
+   */
+  public static final AttributeKey<Boolean> MESSAGING_DESTINATION_PUBLISH_ANONYMOUS =
+      booleanKey("messaging.destination_publish.anonymous");
+
+  /**
+   * The name of the original destination the message was published to
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The name SHOULD uniquely identify a specific queue, topic, or other entity within the
+   *       broker. If the broker doesn't have such notion, the original destination name SHOULD
+   *       uniquely identify the broker.
+   * </ul>
+   */
+  public static final AttributeKey<String> MESSAGING_DESTINATION_PUBLISH_NAME =
+      stringKey("messaging.destination_publish.name");
+
+  /**
+   * Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not
+   * producers.
+   */
+  public static final AttributeKey<String> MESSAGING_KAFKA_CONSUMER_GROUP =
+      stringKey("messaging.kafka.consumer.group");
+
+  /** Partition the message is sent to. */
+  public static final AttributeKey<Long> MESSAGING_KAFKA_DESTINATION_PARTITION =
+      longKey("messaging.kafka.destination.partition");
+
+  /**
+   * Message keys in Kafka are used for grouping alike messages to ensure they're processed on the
+   * same partition. They differ from {@code messaging.message.id} in that they're not unique. If
+   * the key is {@code null}, the attribute MUST NOT be set.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>If the key type is not string, it's string representation has to be supplied for the
+   *       attribute. If the key has no unambiguous, canonical string form, don't include its value.
+   * </ul>
+   */
+  public static final AttributeKey<String> MESSAGING_KAFKA_MESSAGE_KEY =
+      stringKey("messaging.kafka.message.key");
+
+  /** The offset of a record in the corresponding Kafka partition. */
+  public static final AttributeKey<Long> MESSAGING_KAFKA_MESSAGE_OFFSET =
+      longKey("messaging.kafka.message.offset");
+
+  /** A boolean that is true if the message is a tombstone. */
+  public static final AttributeKey<Boolean> MESSAGING_KAFKA_MESSAGE_TOMBSTONE =
+      booleanKey("messaging.kafka.message.tombstone");
+
+  /**
+   * The size of the message body in bytes.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This can refer to both the compressed or uncompressed body size. If both sizes are known,
+   *       the uncompressed body size should be used.
+   * </ul>
+   */
+  public static final AttributeKey<Long> MESSAGING_MESSAGE_BODY_SIZE =
+      longKey("messaging.message.body.size");
+
+  /**
+   * The conversation ID identifying the conversation to which the message belongs, represented as a
+   * string. Sometimes called &quot;Correlation ID&quot;.
+   */
+  public static final AttributeKey<String> MESSAGING_MESSAGE_CONVERSATION_ID =
+      stringKey("messaging.message.conversation_id");
+
+  /**
+   * The size of the message body and metadata in bytes.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This can refer to both the compressed or uncompressed size. If both sizes are known, the
+   *       uncompressed size should be used.
+   * </ul>
+   */
+  public static final AttributeKey<Long> MESSAGING_MESSAGE_ENVELOPE_SIZE =
+      longKey("messaging.message.envelope.size");
+
+  /**
+   * A value used by the messaging system as an identifier for the message, represented as a string.
+   */
+  public static final AttributeKey<String> MESSAGING_MESSAGE_ID = stringKey("messaging.message.id");
+
+  /**
+   * A string identifying the kind of messaging operation.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>If a custom value is used, it MUST be of low cardinality.
+   * </ul>
+   */
+  public static final AttributeKey<String> MESSAGING_OPERATION = stringKey("messaging.operation");
+
+  /** RabbitMQ message routing key. */
+  public static final AttributeKey<String> MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY =
+      stringKey("messaging.rabbitmq.destination.routing_key");
+
+  /**
+   * Name of the RocketMQ producer/consumer group that is handling the message. The client type is
+   * identified by the SpanKind.
+   */
+  public static final AttributeKey<String> MESSAGING_ROCKETMQ_CLIENT_GROUP =
+      stringKey("messaging.rocketmq.client_group");
+
+  /** Model of message consumption. This only applies to consumer spans. */
+  public static final AttributeKey<String> MESSAGING_ROCKETMQ_CONSUMPTION_MODEL =
+      stringKey("messaging.rocketmq.consumption_model");
+
+  /** The delay time level for delay message, which determines the message delay time. */
+  public static final AttributeKey<Long> MESSAGING_ROCKETMQ_MESSAGE_DELAY_TIME_LEVEL =
+      longKey("messaging.rocketmq.message.delay_time_level");
+
+  /**
+   * The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
+   */
+  public static final AttributeKey<Long> MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP =
+      longKey("messaging.rocketmq.message.delivery_timestamp");
+
+  /**
+   * It is essential for FIFO message. Messages that belong to the same message group are always
+   * processed one by one within the same consumer group.
+   */
+  public static final AttributeKey<String> MESSAGING_ROCKETMQ_MESSAGE_GROUP =
+      stringKey("messaging.rocketmq.message.group");
+
+  /** Key(s) of message, another way to mark message besides message id. */
+  public static final AttributeKey<List<String>> MESSAGING_ROCKETMQ_MESSAGE_KEYS =
+      stringArrayKey("messaging.rocketmq.message.keys");
+
+  /** The secondary classifier of message besides topic. */
+  public static final AttributeKey<String> MESSAGING_ROCKETMQ_MESSAGE_TAG =
+      stringKey("messaging.rocketmq.message.tag");
+
+  /** Type of message. */
+  public static final AttributeKey<String> MESSAGING_ROCKETMQ_MESSAGE_TYPE =
+      stringKey("messaging.rocketmq.message.type");
+
+  /** Namespace of RocketMQ resources, resources in different namespaces are individual. */
+  public static final AttributeKey<String> MESSAGING_ROCKETMQ_NAMESPACE =
+      stringKey("messaging.rocketmq.namespace");
+
+  /** A string identifying the messaging system. */
+  public static final AttributeKey<String> MESSAGING_SYSTEM = stringKey("messaging.system");
+
+  /** The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network. */
+  public static final AttributeKey<String> NETWORK_CARRIER_ICC = stringKey("network.carrier.icc");
+
+  /** The mobile carrier country code. */
+  public static final AttributeKey<String> NETWORK_CARRIER_MCC = stringKey("network.carrier.mcc");
+
+  /** The mobile carrier network code. */
+  public static final AttributeKey<String> NETWORK_CARRIER_MNC = stringKey("network.carrier.mnc");
+
+  /** The name of the mobile carrier. */
+  public static final AttributeKey<String> NETWORK_CARRIER_NAME = stringKey("network.carrier.name");
+
+  /**
+   * This describes more details regarding the connection.type. It may be the type of cell
+   * technology connection, but it could be used for describing details about a wifi connection.
+   */
+  public static final AttributeKey<String> NETWORK_CONNECTION_SUBTYPE =
+      stringKey("network.connection.subtype");
+
+  /** The internet connection type. */
+  public static final AttributeKey<String> NETWORK_CONNECTION_TYPE =
+      stringKey("network.connection.type");
+
+  /** Local address of the network connection - IP address or Unix domain socket name. */
+  public static final AttributeKey<String> NETWORK_LOCAL_ADDRESS =
+      stringKey("network.local.address");
+
+  /** Local port number of the network connection. */
+  public static final AttributeKey<Long> NETWORK_LOCAL_PORT = longKey("network.local.port");
+
+  /** Peer address of the network connection - IP address or Unix domain socket name. */
+  public static final AttributeKey<String> NETWORK_PEER_ADDRESS = stringKey("network.peer.address");
+
+  /** Peer port number of the network connection. */
+  public static final AttributeKey<Long> NETWORK_PEER_PORT = longKey("network.peer.port");
+
+  /**
+   * <a href="https://osi-model.com/application-layer/">OSI application layer</a> or non-OSI
+   * equivalent.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The value SHOULD be normalized to lowercase.
+   * </ul>
+   */
+  public static final AttributeKey<String> NETWORK_PROTOCOL_NAME =
+      stringKey("network.protocol.name");
+
+  /**
+   * Version of the protocol specified in {@code network.protocol.name}.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>{@code network.protocol.version} refers to the version of the protocol used and might be
+   *       different from the protocol client's version. If the HTTP client has a version of {@code
+   *       0.27.2}, but sends HTTP version {@code 1.1}, this attribute should be set to {@code 1.1}.
+   * </ul>
+   */
+  public static final AttributeKey<String> NETWORK_PROTOCOL_VERSION =
+      stringKey("network.protocol.version");
+
+  /**
+   * <a href="https://osi-model.com/transport-layer/">OSI transport layer</a> or <a
+   * href="https://wikipedia.org/wiki/Inter-process_communication">inter-process communication
+   * method</a>.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The value SHOULD be normalized to lowercase.
+   *   <li>Consider always setting the transport when setting a port number, since a port number is
+   *       ambiguous without knowing the transport. For example different processes could be
+   *       listening on TCP port 12345 and UDP port 12345.
+   * </ul>
+   */
+  public static final AttributeKey<String> NETWORK_TRANSPORT = stringKey("network.transport");
+
+  /**
+   * <a href="https://osi-model.com/network-layer/">OSI network layer</a> or non-OSI equivalent.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The value SHOULD be normalized to lowercase.
+   * </ul>
+   */
+  public static final AttributeKey<String> NETWORK_TYPE = stringKey("network.type");
+
+  /**
+   * The <a href="https://connect.build/docs/protocol/#error-codes">error codes</a> of the Connect
+   * request. Error codes are always string values.
+   */
+  public static final AttributeKey<String> RPC_CONNECT_RPC_ERROR_CODE =
+      stringKey("rpc.connect_rpc.error_code");
+
+  /**
+   * The <a href="https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md">numeric status
+   * code</a> of the gRPC request.
+   */
+  public static final AttributeKey<Long> RPC_GRPC_STATUS_CODE = longKey("rpc.grpc.status_code");
+
+  /** {@code error.code} property of response if it is an error response. */
+  public static final AttributeKey<Long> RPC_JSONRPC_ERROR_CODE = longKey("rpc.jsonrpc.error_code");
+
+  /** {@code error.message} property of response if it is an error response. */
+  public static final AttributeKey<String> RPC_JSONRPC_ERROR_MESSAGE =
+      stringKey("rpc.jsonrpc.error_message");
+
+  /**
+   * {@code id} property of request or response. Since protocol allows id to be int, string, {@code
+   * null} or missing (for notifications), value is expected to be cast to string for simplicity.
+   * Use empty string in case of {@code null} value. Omit entirely if this is a notification.
+   */
+  public static final AttributeKey<String> RPC_JSONRPC_REQUEST_ID =
+      stringKey("rpc.jsonrpc.request_id");
+
+  /**
+   * Protocol version as in {@code jsonrpc} property of request/response. Since JSON-RPC 1.0 doesn't
+   * specify this, the value can be omitted.
+   */
+  public static final AttributeKey<String> RPC_JSONRPC_VERSION = stringKey("rpc.jsonrpc.version");
+
+  /**
+   * The name of the (logical) method being called, must be equal to the $method part in the span
+   * name.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This is the logical name of the method from the RPC interface perspective, which can be
+   *       different from the name of any implementing method/function. The {@code code.function}
+   *       attribute may be used to store the latter (e.g., method actually executing the call on
+   *       the server side, RPC client stub method on the client side).
+   * </ul>
+   */
+  public static final AttributeKey<String> RPC_METHOD = stringKey("rpc.method");
+
+  /**
+   * The full (logical) name of the service being called, including its package name, if applicable.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This is the logical name of the service from the RPC interface perspective, which can be
+   *       different from the name of any implementing class. The {@code code.namespace} attribute
+   *       may be used to store the latter (despite the attribute name, it may include a class name;
+   *       e.g., class with method actually executing the call on the server side, RPC client stub
+   *       class on the client side).
+   * </ul>
+   */
+  public static final AttributeKey<String> RPC_SERVICE = stringKey("rpc.service");
+
+  /** A string identifying the remoting system. See below for a list of well-known identifiers. */
+  public static final AttributeKey<String> RPC_SYSTEM = stringKey("rpc.system");
+
+  /** Current &quot;managed&quot; thread ID (as opposed to OS thread ID). */
+  public static final AttributeKey<Long> THREAD_ID = longKey("thread.id");
+
+  /** Current thread name. */
+  public static final AttributeKey<String> THREAD_NAME = stringKey("thread.name");
+
+  /** The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.5">URI fragment</a> component */
+  public static final AttributeKey<String> URL_FRAGMENT = stringKey("url.fragment");
+
+  /**
+   * Absolute URL describing a network resource according to <a
+   * href="https://www.rfc-editor.org/rfc/rfc3986">RFC3986</a>
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>For network calls, URL usually has {@code scheme://host[:port][path][?query][#fragment]}
+   *       format, where the fragment is not transmitted over HTTP, but if it is known, it SHOULD be
+   *       included nevertheless. {@code url.full} MUST NOT contain credentials passed via URL in
+   *       form of {@code https://username:password@www.example.com/}. In such case username and
+   *       password SHOULD be redacted and attribute's value SHOULD be {@code
+   *       https://REDACTED:REDACTED@www.example.com/}. {@code url.full} SHOULD capture the absolute
+   *       URL when it is available (or can be reconstructed) and SHOULD NOT be validated or
+   *       modified except for sanitizing purposes.
+   * </ul>
+   */
+  public static final AttributeKey<String> URL_FULL = stringKey("url.full");
+
+  /** The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.3">URI path</a> component */
+  public static final AttributeKey<String> URL_PATH = stringKey("url.path");
+
+  /**
+   * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.4">URI query</a> component
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Sensitive content provided in query string SHOULD be scrubbed when instrumentations can
+   *       identify it.
+   * </ul>
+   */
+  public static final AttributeKey<String> URL_QUERY = stringKey("url.query");
+
+  /**
+   * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.1">URI scheme</a> component
+   * identifying the used protocol.
+   */
+  public static final AttributeKey<String> URL_SCHEME = stringKey("url.scheme");
+
+  /**
+   * Value of the <a href="https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent">HTTP
+   * User-Agent</a> header sent by the client.
+   */
+  public static final AttributeKey<String> USER_AGENT_ORIGINAL = stringKey("user_agent.original");
+
+  /**
+   * Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix
+   * domain socket name.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>When observed from the client side, and when communicating through an intermediary,
+   *       {@code server.address} SHOULD represent the server address behind any intermediaries, for
+   *       example proxies, if it's available.
+   * </ul>
+   */
+  public static final AttributeKey<String> SERVER_ADDRESS = stringKey("server.address");
+
+  /**
+   * Server port number.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>When observed from the client side, and when communicating through an intermediary,
+   *       {@code server.port} SHOULD represent the server port behind any intermediaries, for
+   *       example proxies, if it's available.
+   * </ul>
+   */
+  public static final AttributeKey<Long> SERVER_PORT = longKey("server.port");
+
+  /** A unique id to identify a session. */
+  public static final AttributeKey<String> SESSION_ID = stringKey("session.id");
+
+  /** The previous {@code session.id} for this user, when known. */
+  public static final AttributeKey<String> SESSION_PREVIOUS_ID = stringKey("session.previous_id");
+
+  /**
+   * Source address - domain name if available without reverse DNS lookup; otherwise, IP address or
+   * Unix domain socket name.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>When observed from the destination side, and when communicating through an intermediary,
+   *       {@code source.address} SHOULD represent the source address behind any intermediaries, for
+   *       example proxies, if it's available.
+   * </ul>
+   */
+  public static final AttributeKey<String> SOURCE_ADDRESS = stringKey("source.address");
+
+  /** Source port number */
+  public static final AttributeKey<Long> SOURCE_PORT = longKey("source.port");
+
+  /**
+   * The full invoked ARN as provided on the {@code Context} passed to the function ({@code
+   * Lambda-Runtime-Invoked-Function-Arn} header on the {@code /runtime/invocation/next}
+   * applicable).
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This may be different from {@code cloud.resource_id} if an alias is involved.
+   * </ul>
+   */
+  public static final AttributeKey<String> AWS_LAMBDA_INVOKED_ARN =
+      stringKey("aws.lambda.invoked_arn");
+
+  /**
+   * The <a
+   * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id">event_id</a>
+   * uniquely identifies the event.
+   */
+  public static final AttributeKey<String> CLOUDEVENTS_EVENT_ID = stringKey("cloudevents.event_id");
+
+  /**
+   * The <a
+   * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#source-1">source</a>
+   * identifies the context in which an event happened.
+   */
+  public static final AttributeKey<String> CLOUDEVENTS_EVENT_SOURCE =
+      stringKey("cloudevents.event_source");
+
+  /**
+   * The <a
+   * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#specversion">version
+   * of the CloudEvents specification</a> which the event uses.
+   */
+  public static final AttributeKey<String> CLOUDEVENTS_EVENT_SPEC_VERSION =
+      stringKey("cloudevents.event_spec_version");
+
+  /**
+   * The <a
+   * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#subject">subject</a>
+   * of the event in the context of the event producer (identified by source).
+   */
+  public static final AttributeKey<String> CLOUDEVENTS_EVENT_SUBJECT =
+      stringKey("cloudevents.event_subject");
+
+  /**
+   * The <a
+   * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type">event_type</a>
+   * contains a value describing the type of event related to the originating occurrence.
+   */
+  public static final AttributeKey<String> CLOUDEVENTS_EVENT_TYPE =
+      stringKey("cloudevents.event_type");
+
+  /**
+   * Parent-child Reference type
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The causal relationship between a child Span and a parent Span.
+   * </ul>
+   */
+  public static final AttributeKey<String> OPENTRACING_REF_TYPE = stringKey("opentracing.ref_type");
+
+  /**
+   * The connection string used to connect to the database. It is recommended to remove embedded
+   * credentials.
+   */
+  public static final AttributeKey<String> DB_CONNECTION_STRING = stringKey("db.connection_string");
+
+  /**
+   * The fully-qualified class name of the <a
+   * href="https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/">Java Database Connectivity
+   * (JDBC)</a> driver used to connect.
+   */
+  public static final AttributeKey<String> DB_JDBC_DRIVER_CLASSNAME =
+      stringKey("db.jdbc.driver_classname");
+
+  /**
+   * This attribute is used to report the name of the database being accessed. For commands that
+   * switch the database, this should be set to the target database (even if the command fails).
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>In some SQL databases, the database name to be used is called &quot;schema name&quot;. In
+   *       case there are multiple layers that could be considered for database name (e.g. Oracle
+   *       instance name and schema name), the database name to be used is the more specific layer
+   *       (e.g. Oracle schema name).
+   * </ul>
+   */
+  public static final AttributeKey<String> DB_NAME = stringKey("db.name");
+
+  /**
+   * The name of the operation being executed, e.g. the <a
+   * href="https://docs.mongodb.com/manual/reference/command/#database-operations">MongoDB command
+   * name</a> such as {@code findAndModify}, or the SQL keyword.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>When setting this to an SQL keyword, it is not recommended to attempt any client-side
+   *       parsing of {@code db.statement} just to get this property, but it should be set if the
+   *       operation name is provided by the library being instrumented. If the SQL statement has an
+   *       ambiguous operation, or performs more than one operation, this value may be omitted.
+   * </ul>
+   */
+  public static final AttributeKey<String> DB_OPERATION = stringKey("db.operation");
+
+  /** The database statement being executed. */
+  public static final AttributeKey<String> DB_STATEMENT = stringKey("db.statement");
+
+  /**
+   * An identifier for the database management system (DBMS) product being used. See below for a
+   * list of well-known identifiers.
+   */
+  public static final AttributeKey<String> DB_SYSTEM = stringKey("db.system");
+
+  /** Username for accessing the database. */
+  public static final AttributeKey<String> DB_USER = stringKey("db.user");
+
+  /**
+   * The Microsoft SQL Server <a
+   * href="https://docs.microsoft.com/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15">instance
+   * name</a> connecting to. This name is used to determine the port of a named instance.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>If setting a {@code db.mssql.instance_name}, {@code server.port} is no longer required
+   *       (but still recommended if non-standard).
+   * </ul>
+   */
+  public static final AttributeKey<String> DB_MSSQL_INSTANCE_NAME =
+      stringKey("db.mssql.instance_name");
+
+  /**
+   * The consistency level of the query. Based on consistency values from <a
+   * href="https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html">CQL</a>.
+   */
+  public static final AttributeKey<String> DB_CASSANDRA_CONSISTENCY_LEVEL =
+      stringKey("db.cassandra.consistency_level");
+
+  /** The data center of the coordinating node for a query. */
+  public static final AttributeKey<String> DB_CASSANDRA_COORDINATOR_DC =
+      stringKey("db.cassandra.coordinator.dc");
+
+  /** The ID of the coordinating node for a query. */
+  public static final AttributeKey<String> DB_CASSANDRA_COORDINATOR_ID =
+      stringKey("db.cassandra.coordinator.id");
+
+  /** Whether or not the query is idempotent. */
+  public static final AttributeKey<Boolean> DB_CASSANDRA_IDEMPOTENCE =
+      booleanKey("db.cassandra.idempotence");
+
+  /** The fetch size used for paging, i.e. how many rows will be returned at once. */
+  public static final AttributeKey<Long> DB_CASSANDRA_PAGE_SIZE = longKey("db.cassandra.page_size");
+
+  /**
+   * The number of times a query was speculatively executed. Not set or {@code 0} if the query was
+   * not executed speculatively.
+   */
+  public static final AttributeKey<Long> DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT =
+      longKey("db.cassandra.speculative_execution_count");
+
+  /**
+   * The name of the primary table that the operation is acting upon, including the keyspace name
+   * (if applicable).
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This mirrors the db.sql.table attribute but references cassandra rather than sql. It is
+   *       not recommended to attempt any client-side parsing of {@code db.statement} just to get
+   *       this property, but it should be set if it is provided by the library being instrumented.
+   *       If the operation is acting upon an anonymous table, or more than one table, this value
+   *       MUST NOT be set.
+   * </ul>
+   */
+  public static final AttributeKey<String> DB_CASSANDRA_TABLE = stringKey("db.cassandra.table");
+
+  /**
+   * The index of the database being accessed as used in the <a
+   * href="https://redis.io/commands/select">{@code SELECT} command</a>, provided as an integer. To
+   * be used instead of the generic {@code db.name} attribute.
+   */
+  public static final AttributeKey<Long> DB_REDIS_DATABASE_INDEX =
+      longKey("db.redis.database_index");
+
+  /** The collection being accessed within the database stated in {@code db.name}. */
+  public static final AttributeKey<String> DB_MONGODB_COLLECTION =
+      stringKey("db.mongodb.collection");
+
+  /** Represents the identifier of an Elasticsearch cluster. */
+  public static final AttributeKey<String> DB_ELASTICSEARCH_CLUSTER_NAME =
+      stringKey("db.elasticsearch.cluster.name");
+
+  /**
+   * Represents the human-readable identifier of the node/instance to which a request was routed.
+   */
+  public static final AttributeKey<String> DB_ELASTICSEARCH_NODE_NAME =
+      stringKey("db.elasticsearch.node.name");
+
+  /**
+   * The name of the primary table that the operation is acting upon, including the database name
+   * (if applicable).
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>It is not recommended to attempt any client-side parsing of {@code db.statement} just to
+   *       get this property, but it should be set if it is provided by the library being
+   *       instrumented. If the operation is acting upon an anonymous table, or more than one table,
+   *       this value MUST NOT be set.
+   * </ul>
+   */
+  public static final AttributeKey<String> DB_SQL_TABLE = stringKey("db.sql.table");
+
+  /** Unique Cosmos client instance id. */
+  public static final AttributeKey<String> DB_COSMOSDB_CLIENT_ID =
+      stringKey("db.cosmosdb.client_id");
+
+  /** Cosmos client connection mode. */
+  public static final AttributeKey<String> DB_COSMOSDB_CONNECTION_MODE =
+      stringKey("db.cosmosdb.connection_mode");
+
+  /** Cosmos DB container name. */
+  public static final AttributeKey<String> DB_COSMOSDB_CONTAINER =
+      stringKey("db.cosmosdb.container");
+
+  /** CosmosDB Operation Type. */
+  public static final AttributeKey<String> DB_COSMOSDB_OPERATION_TYPE =
+      stringKey("db.cosmosdb.operation_type");
+
+  /** RU consumed for that operation */
+  public static final AttributeKey<Double> DB_COSMOSDB_REQUEST_CHARGE =
+      doubleKey("db.cosmosdb.request_charge");
+
+  /** Request payload size in bytes */
+  public static final AttributeKey<Long> DB_COSMOSDB_REQUEST_CONTENT_LENGTH =
+      longKey("db.cosmosdb.request_content_length");
+
+  /** Cosmos DB status code. */
+  public static final AttributeKey<Long> DB_COSMOSDB_STATUS_CODE =
+      longKey("db.cosmosdb.status_code");
+
+  /** Cosmos DB sub status code. */
+  public static final AttributeKey<Long> DB_COSMOSDB_SUB_STATUS_CODE =
+      longKey("db.cosmosdb.sub_status_code");
+
+  /**
+   * Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set if the status
+   * code is UNSET.
+   */
+  public static final AttributeKey<String> OTEL_STATUS_CODE = stringKey("otel.status_code");
+
+  /** Description of the Status if it has a value, otherwise not set. */
+  public static final AttributeKey<String> OTEL_STATUS_DESCRIPTION =
+      stringKey("otel.status_description");
+
+  /** The invocation ID of the current function invocation. */
+  public static final AttributeKey<String> FAAS_INVOCATION_ID = stringKey("faas.invocation_id");
+
+  /**
+   * The name of the source on which the triggering operation was performed. For example, in Cloud
+   * Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name.
+   */
+  public static final AttributeKey<String> FAAS_DOCUMENT_COLLECTION =
+      stringKey("faas.document.collection");
+
+  /**
+   * The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the
+   * name of the file, and in Cosmos DB the table name.
+   */
+  public static final AttributeKey<String> FAAS_DOCUMENT_NAME = stringKey("faas.document.name");
+
+  /** Describes the type of the operation that was performed on the data. */
+  public static final AttributeKey<String> FAAS_DOCUMENT_OPERATION =
+      stringKey("faas.document.operation");
+
+  /**
+   * A string containing the time when the data was accessed in the <a
+   * href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO 8601</a> format expressed in
+   * <a href="https://www.w3.org/TR/NOTE-datetime">UTC</a>.
+   */
+  public static final AttributeKey<String> FAAS_DOCUMENT_TIME = stringKey("faas.document.time");
+
+  /**
+   * A string containing the schedule period as <a
+   * href="https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm">Cron
+   * Expression</a>.
+   */
+  public static final AttributeKey<String> FAAS_CRON = stringKey("faas.cron");
+
+  /**
+   * A string containing the function invocation time in the <a
+   * href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO 8601</a> format expressed in
+   * <a href="https://www.w3.org/TR/NOTE-datetime">UTC</a>.
+   */
+  public static final AttributeKey<String> FAAS_TIME = stringKey("faas.time");
+
+  /**
+   * A boolean that is true if the serverless function is executed for the first time (aka
+   * cold-start).
+   */
+  public static final AttributeKey<Boolean> FAAS_COLDSTART = booleanKey("faas.coldstart");
+
+  /** The unique identifier of the feature flag. */
+  public static final AttributeKey<String> FEATURE_FLAG_KEY = stringKey("feature_flag.key");
+
+  /** The name of the service provider that performs the flag evaluation. */
+  public static final AttributeKey<String> FEATURE_FLAG_PROVIDER_NAME =
+      stringKey("feature_flag.provider_name");
+
+  /**
+   * SHOULD be a semantic identifier for a value. If one is unavailable, a stringified version of
+   * the value can be used.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>A semantic identifier, commonly referred to as a variant, provides a means for referring
+   *       to a value without including the value itself. This can provide additional context for
+   *       understanding the meaning behind a value. For example, the variant {@code red} maybe be
+   *       used for the value {@code #c05543}.
+   *   <li>A stringified version of the value can be used in situations where a semantic identifier
+   *       is unavailable. String representation of the value should be determined by the
+   *       implementer.
+   * </ul>
+   */
+  public static final AttributeKey<String> FEATURE_FLAG_VARIANT = stringKey("feature_flag.variant");
+
+  /**
+   * The AWS request ID as returned in the response headers {@code x-amz-request-id} or {@code
+   * x-amz-requestid}.
+   */
+  public static final AttributeKey<String> AWS_REQUEST_ID = stringKey("aws.request_id");
+
+  /** The value of the {@code AttributesToGet} request parameter. */
+  public static final AttributeKey<List<String>> AWS_DYNAMODB_ATTRIBUTES_TO_GET =
+      stringArrayKey("aws.dynamodb.attributes_to_get");
+
+  /** The value of the {@code ConsistentRead} request parameter. */
+  public static final AttributeKey<Boolean> AWS_DYNAMODB_CONSISTENT_READ =
+      booleanKey("aws.dynamodb.consistent_read");
+
+  /** The JSON-serialized value of each item in the {@code ConsumedCapacity} response field. */
+  public static final AttributeKey<List<String>> AWS_DYNAMODB_CONSUMED_CAPACITY =
+      stringArrayKey("aws.dynamodb.consumed_capacity");
+
+  /** The value of the {@code IndexName} request parameter. */
+  public static final AttributeKey<String> AWS_DYNAMODB_INDEX_NAME =
+      stringKey("aws.dynamodb.index_name");
+
+  /** The JSON-serialized value of the {@code ItemCollectionMetrics} response field. */
+  public static final AttributeKey<String> AWS_DYNAMODB_ITEM_COLLECTION_METRICS =
+      stringKey("aws.dynamodb.item_collection_metrics");
+
+  /** The value of the {@code Limit} request parameter. */
+  public static final AttributeKey<Long> AWS_DYNAMODB_LIMIT = longKey("aws.dynamodb.limit");
+
+  /** The value of the {@code ProjectionExpression} request parameter. */
+  public static final AttributeKey<String> AWS_DYNAMODB_PROJECTION =
+      stringKey("aws.dynamodb.projection");
+
+  /** The value of the {@code ProvisionedThroughput.ReadCapacityUnits} request parameter. */
+  public static final AttributeKey<Double> AWS_DYNAMODB_PROVISIONED_READ_CAPACITY =
+      doubleKey("aws.dynamodb.provisioned_read_capacity");
+
+  /** The value of the {@code ProvisionedThroughput.WriteCapacityUnits} request parameter. */
+  public static final AttributeKey<Double> AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY =
+      doubleKey("aws.dynamodb.provisioned_write_capacity");
+
+  /** The value of the {@code Select} request parameter. */
+  public static final AttributeKey<String> AWS_DYNAMODB_SELECT = stringKey("aws.dynamodb.select");
+
+  /** The keys in the {@code RequestItems} object field. */
+  public static final AttributeKey<List<String>> AWS_DYNAMODB_TABLE_NAMES =
+      stringArrayKey("aws.dynamodb.table_names");
+
+  /** The JSON-serialized value of each item of the {@code GlobalSecondaryIndexes} request field */
+  public static final AttributeKey<List<String>> AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES =
+      stringArrayKey("aws.dynamodb.global_secondary_indexes");
+
+  /** The JSON-serialized value of each item of the {@code LocalSecondaryIndexes} request field. */
+  public static final AttributeKey<List<String>> AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES =
+      stringArrayKey("aws.dynamodb.local_secondary_indexes");
+
+  /** The value of the {@code ExclusiveStartTableName} request parameter. */
+  public static final AttributeKey<String> AWS_DYNAMODB_EXCLUSIVE_START_TABLE =
+      stringKey("aws.dynamodb.exclusive_start_table");
+
+  /** The the number of items in the {@code TableNames} response parameter. */
+  public static final AttributeKey<Long> AWS_DYNAMODB_TABLE_COUNT =
+      longKey("aws.dynamodb.table_count");
+
+  /** The value of the {@code ScanIndexForward} request parameter. */
+  public static final AttributeKey<Boolean> AWS_DYNAMODB_SCAN_FORWARD =
+      booleanKey("aws.dynamodb.scan_forward");
+
+  /** The value of the {@code Count} response parameter. */
+  public static final AttributeKey<Long> AWS_DYNAMODB_COUNT = longKey("aws.dynamodb.count");
+
+  /** The value of the {@code ScannedCount} response parameter. */
+  public static final AttributeKey<Long> AWS_DYNAMODB_SCANNED_COUNT =
+      longKey("aws.dynamodb.scanned_count");
+
+  /** The value of the {@code Segment} request parameter. */
+  public static final AttributeKey<Long> AWS_DYNAMODB_SEGMENT = longKey("aws.dynamodb.segment");
+
+  /** The value of the {@code TotalSegments} request parameter. */
+  public static final AttributeKey<Long> AWS_DYNAMODB_TOTAL_SEGMENTS =
+      longKey("aws.dynamodb.total_segments");
+
+  /** The JSON-serialized value of each item in the {@code AttributeDefinitions} request field. */
+  public static final AttributeKey<List<String>> AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS =
+      stringArrayKey("aws.dynamodb.attribute_definitions");
+
+  /**
+   * The JSON-serialized value of each item in the the {@code GlobalSecondaryIndexUpdates} request
+   * field.
+   */
+  public static final AttributeKey<List<String>> AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES =
+      stringArrayKey("aws.dynamodb.global_secondary_index_updates");
+
+  /**
+   * The S3 bucket name the request refers to. Corresponds to the {@code --bucket} parameter of the
+   * <a href="https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html">S3 API</a>
+   * operations.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code bucket} attribute is applicable to all S3 operations that reference a bucket,
+   *       i.e. that require the bucket name as a mandatory parameter. This applies to almost all S3
+   *       operations except {@code list-buckets}.
+   * </ul>
+   */
+  public static final AttributeKey<String> AWS_S3_BUCKET = stringKey("aws.s3.bucket");
+
+  /**
+   * The source object (in the form {@code bucket}/{@code key}) for the copy operation.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code copy_source} attribute applies to S3 copy operations and corresponds to the
+   *       {@code --copy-source} parameter of the <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html">copy-object
+   *       operation within the S3 API</a>. This applies in particular to the following operations:
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html">copy-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a>
+   * </ul>
+   */
+  public static final AttributeKey<String> AWS_S3_COPY_SOURCE = stringKey("aws.s3.copy_source");
+
+  /**
+   * The delete request container that specifies the objects to be deleted.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code delete} attribute is only applicable to the <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html">delete-object</a>
+   *       operation. The {@code delete} attribute corresponds to the {@code --delete} parameter of
+   *       the <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-objects.html">delete-objects
+   *       operation within the S3 API</a>.
+   * </ul>
+   */
+  public static final AttributeKey<String> AWS_S3_DELETE = stringKey("aws.s3.delete");
+
+  /**
+   * The S3 object key the request refers to. Corresponds to the {@code --key} parameter of the <a
+   * href="https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html">S3 API</a> operations.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code key} attribute is applicable to all object-related S3 operations, i.e. that
+   *       require the object key as a mandatory parameter. This applies in particular to the
+   *       following operations:
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html">copy-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html">delete-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/get-object.html">get-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/head-object.html">head-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html">put-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html">restore-object</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/select-object-content.html">select-object-content</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/abort-multipart-upload.html">abort-multipart-upload</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/complete-multipart-upload.html">complete-multipart-upload</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/create-multipart-upload.html">create-multipart-upload</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/list-parts.html">list-parts</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html">upload-part</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a>
+   * </ul>
+   */
+  public static final AttributeKey<String> AWS_S3_KEY = stringKey("aws.s3.key");
+
+  /**
+   * The part number of the part being uploaded in a multipart-upload operation. This is a positive
+   * integer between 1 and 10,000.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code part_number} attribute is only applicable to the <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html">upload-part</a>
+   *       and <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a>
+   *       operations. The {@code part_number} attribute corresponds to the {@code --part-number}
+   *       parameter of the <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html">upload-part
+   *       operation within the S3 API</a>.
+   * </ul>
+   */
+  public static final AttributeKey<Long> AWS_S3_PART_NUMBER = longKey("aws.s3.part_number");
+
+  /**
+   * Upload ID that identifies the multipart upload.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The {@code upload_id} attribute applies to S3 multipart-upload operations and corresponds
+   *       to the {@code --upload-id} parameter of the <a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html">S3 API</a>
+   *       multipart operations. This applies in particular to the following operations:
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/abort-multipart-upload.html">abort-multipart-upload</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/complete-multipart-upload.html">complete-multipart-upload</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/list-parts.html">list-parts</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html">upload-part</a>
+   *   <li><a
+   *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a>
+   * </ul>
+   */
+  public static final AttributeKey<String> AWS_S3_UPLOAD_ID = stringKey("aws.s3.upload_id");
+
+  /**
+   * The GraphQL document being executed.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The value may be sanitized to exclude sensitive information.
+   * </ul>
+   */
+  public static final AttributeKey<String> GRAPHQL_DOCUMENT = stringKey("graphql.document");
+
+  /** The name of the operation being executed. */
+  public static final AttributeKey<String> GRAPHQL_OPERATION_NAME =
+      stringKey("graphql.operation.name");
+
+  /** The type of the operation being executed. */
+  public static final AttributeKey<String> GRAPHQL_OPERATION_TYPE =
+      stringKey("graphql.operation.type");
+
+  /** Compressed size of the message in bytes. */
+  public static final AttributeKey<Long> MESSAGE_COMPRESSED_SIZE =
+      longKey("message.compressed_size");
+
+  /**
+   * MUST be calculated as two different counters starting from {@code 1} one for sent messages and
+   * one for received message.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This way we guarantee that the values will be consistent between different
+   *       implementations.
+   * </ul>
+   */
+  public static final AttributeKey<Long> MESSAGE_ID = longKey("message.id");
+
+  /** Whether this is a received or sent message. */
+  public static final AttributeKey<String> MESSAGE_TYPE = stringKey("message.type");
+
+  /** Uncompressed size of the message in bytes. */
+  public static final AttributeKey<Long> MESSAGE_UNCOMPRESSED_SIZE =
+      longKey("message.uncompressed_size");
+
+  /**
+   * SHOULD be set to true if the exception event is recorded at a point where it is known that the
+   * exception is escaping the scope of the span.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>An exception is considered to have escaped (or left) the scope of a span, if that span is
+   *       ended while the exception is still logically &quot;in flight&quot;. This may be actually
+   *       &quot;in flight&quot; in some languages (e.g. if the exception is passed to a Context
+   *       manager's {@code __exit__} method in Python) but will usually be caught at the point of
+   *       recording the exception in most languages.
+   *   <li>It is usually not possible to determine at the point where an exception is thrown whether
+   *       it will escape the scope of a span. However, it is trivial to know that an exception will
+   *       escape, if one checks for an active exception just before ending the span, as done in the
+   *       <a href="#recording-an-exception">example above</a>.
+   *   <li>It follows that an exception may still escape the scope of the span even if the {@code
+   *       exception.escaped} attribute was not set or set to false, since the event might have been
+   *       recorded at a time where it was not clear whether the exception will escape.
+   * </ul>
+   */
+  public static final AttributeKey<Boolean> EXCEPTION_ESCAPED = booleanKey("exception.escaped");
+
+  /**
+   * HTTP request headers, {@code <key>} being the normalized HTTP Header name (lowercase), the
+   * value being the header values.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Instrumentations SHOULD require an explicit configuration of which headers are to be
+   *       captured. Including all request headers can be a security risk - explicit configuration
+   *       helps avoid leaking sensitive information. The {@code User-Agent} header is already
+   *       captured in the {@code user_agent.original} attribute. Users MAY explicitly configure
+   *       instrumentations to capture them even though it is not recommended. The attribute value
+   *       MUST consist of either multiple header values as an array of strings or a single-item
+   *       array containing a possibly comma-concatenated string, depending on the way the HTTP
+   *       library provides access to headers.
+   * </ul>
+   */
+  public static final AttributeKeyTemplate<List<String>> HTTP_REQUEST_HEADER =
+      stringArrayKeyTemplate("http.request.header");
+
+  /**
+   * HTTP response headers, {@code <key>} being the normalized HTTP Header name (lowercase), the
+   * value being the header values.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Instrumentations SHOULD require an explicit configuration of which headers are to be
+   *       captured. Including all response headers can be a security risk - explicit configuration
+   *       helps avoid leaking sensitive information. Users MAY explicitly configure
+   *       instrumentations to capture them even though it is not recommended. The attribute value
+   *       MUST consist of either multiple header values as an array of strings or a single-item
+   *       array containing a possibly comma-concatenated string, depending on the way the HTTP
+   *       library provides access to headers.
+   * </ul>
+   */
+  public static final AttributeKeyTemplate<List<String>> HTTP_RESPONSE_HEADER =
+      stringArrayKeyTemplate("http.response.header");
+
+  /**
+   * Connect request metadata, {@code <key>} being the normalized Connect Metadata key (lowercase),
+   * the value being the metadata values.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Instrumentations SHOULD require an explicit configuration of which metadata values are to
+   *       be captured. Including all request metadata values can be a security risk - explicit
+   *       configuration helps avoid leaking sensitive information.
+   * </ul>
+   */
+  public static final AttributeKeyTemplate<List<String>> RPC_CONNECT_RPC_REQUEST_METADATA =
+      stringArrayKeyTemplate("rpc.connect_rpc.request.metadata");
+
+  /**
+   * Connect response metadata, {@code <key>} being the normalized Connect Metadata key (lowercase),
+   * the value being the metadata values.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Instrumentations SHOULD require an explicit configuration of which metadata values are to
+   *       be captured. Including all response metadata values can be a security risk - explicit
+   *       configuration helps avoid leaking sensitive information.
+   * </ul>
+   */
+  public static final AttributeKeyTemplate<List<String>> RPC_CONNECT_RPC_RESPONSE_METADATA =
+      stringArrayKeyTemplate("rpc.connect_rpc.response.metadata");
+
+  /**
+   * gRPC request metadata, {@code <key>} being the normalized gRPC Metadata key (lowercase), the
+   * value being the metadata values.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Instrumentations SHOULD require an explicit configuration of which metadata values are to
+   *       be captured. Including all request metadata values can be a security risk - explicit
+   *       configuration helps avoid leaking sensitive information.
+   * </ul>
+   */
+  public static final AttributeKeyTemplate<List<String>> RPC_GRPC_REQUEST_METADATA =
+      stringArrayKeyTemplate("rpc.grpc.request.metadata");
+
+  /**
+   * gRPC response metadata, {@code <key>} being the normalized gRPC Metadata key (lowercase), the
+   * value being the metadata values.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Instrumentations SHOULD require an explicit configuration of which metadata values are to
+   *       be captured. Including all response metadata values can be a security risk - explicit
+   *       configuration helps avoid leaking sensitive information.
+   * </ul>
+   */
+  public static final AttributeKeyTemplate<List<String>> RPC_GRPC_RESPONSE_METADATA =
+      stringArrayKeyTemplate("rpc.grpc.response.metadata");
+
+  /**
+   * A dynamic value in the url path.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Many Elasticsearch url paths allow dynamic values. These SHOULD be recorded in span
+   *       attributes in the format {@code db.elasticsearch.path_parts.<key>}, where {@code <key>}
+   *       is the url path part name. The implementation SHOULD reference the <a
+   *       href="https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json">elasticsearch
+   *       schema</a> in order to map the path part values to their names.
+   * </ul>
+   */
+  public static final AttributeKeyTemplate<String> DB_ELASTICSEARCH_PATH_PARTS =
+      stringKeyTemplate("db.elasticsearch.path_parts");
+
+  // Enum definitions
+  public static final class ErrorTypeValues {
+    /**
+     * A fallback error value to be used when the instrumentation doesn&#39;t define a custom value.
+     */
+    public static final String OTHER = "_OTHER";
+
+    private ErrorTypeValues() {}
+  }
+
+  public static final class FaasInvokedProviderValues {
+    /** Alibaba Cloud. */
+    public static final String ALIBABA_CLOUD = "alibaba_cloud";
+
+    /** Amazon Web Services. */
+    public static final String AWS = "aws";
+
+    /** Microsoft Azure. */
+    public static final String AZURE = "azure";
+
+    /** Google Cloud Platform. */
+    public static final String GCP = "gcp";
+
+    /** Tencent Cloud. */
+    public static final String TENCENT_CLOUD = "tencent_cloud";
+
+    private FaasInvokedProviderValues() {}
+  }
+
+  public static final class FaasTriggerValues {
+    /** A response to some data source operation such as a database or filesystem read/write. */
+    public static final String DATASOURCE = "datasource";
+
+    /** To provide an answer to an inbound HTTP request. */
+    public static final String HTTP = "http";
+
+    /** A function is set to be executed when messages are sent to a messaging system. */
+    public static final String PUBSUB = "pubsub";
+
+    /** A function is scheduled to be executed regularly. */
+    public static final String TIMER = "timer";
+
+    /** If none of the others apply. */
+    public static final String OTHER = "other";
+
+    private FaasTriggerValues() {}
+  }
+
+  public static final class EventDomainValues {
+    /** Events from browser apps. */
+    public static final String BROWSER = "browser";
+
+    /** Events from mobile apps. */
+    public static final String DEVICE = "device";
+
+    /** Events from Kubernetes. */
+    public static final String K8S = "k8s";
+
+    private EventDomainValues() {}
+  }
+
+  public static final class LogIostreamValues {
+    /** Logs from stdout stream. */
+    public static final String STDOUT = "stdout";
+
+    /** Events from stderr stream. */
+    public static final String STDERR = "stderr";
+
+    private LogIostreamValues() {}
+  }
+
+  public static final class IosStateValues {
+    /**
+     * The app has become `active`. Associated with UIKit notification `applicationDidBecomeActive`.
+     */
+    public static final String ACTIVE = "active";
+
+    /**
+     * The app is now `inactive`. Associated with UIKit notification `applicationWillResignActive`.
+     */
+    public static final String INACTIVE = "inactive";
+
+    /**
+     * The app is now in the background. This value is associated with UIKit notification
+     * `applicationDidEnterBackground`.
+     */
+    public static final String BACKGROUND = "background";
+
+    /**
+     * The app is now in the foreground. This value is associated with UIKit notification
+     * `applicationWillEnterForeground`.
+     */
+    public static final String FOREGROUND = "foreground";
+
+    /**
+     * The app is about to terminate. Associated with UIKit notification `applicationWillTerminate`.
+     */
+    public static final String TERMINATE = "terminate";
+
+    private IosStateValues() {}
+  }
+
+  public static final class AndroidStateValues {
+    /**
+     * Any time before Activity.onResume() or, if the app has no Activity, Context.startService()
+     * has been called in the app for the first time.
+     */
+    public static final String CREATED = "created";
+
+    /**
+     * Any time after Activity.onPause() or, if the app has no Activity, Context.stopService() has
+     * been called when the app was in the foreground state.
+     */
+    public static final String BACKGROUND = "background";
+
+    /**
+     * Any time after Activity.onResume() or, if the app has no Activity, Context.startService() has
+     * been called when the app was in either the created or background states.
+     */
+    public static final String FOREGROUND = "foreground";
+
+    private AndroidStateValues() {}
+  }
+
+  public static final class StateValues {
+    /** idle. */
+    public static final String IDLE = "idle";
+
+    /** used. */
+    public static final String USED = "used";
+
+    private StateValues() {}
+  }
+
+  public static final class JvmMemoryTypeValues {
+    /** Heap memory. */
+    public static final String HEAP = "heap";
+
+    /** Non-heap memory. */
+    public static final String NON_HEAP = "non_heap";
+
+    private JvmMemoryTypeValues() {}
+  }
+
+  public static final class JvmThreadStateValues {
+    /** A thread that has not yet started is in this state. */
+    public static final String NEW = "new";
+
+    /** A thread executing in the Java virtual machine is in this state. */
+    public static final String RUNNABLE = "runnable";
+
+    /** A thread that is blocked waiting for a monitor lock is in this state. */
+    public static final String BLOCKED = "blocked";
+
+    /**
+     * A thread that is waiting indefinitely for another thread to perform a particular action is in
+     * this state.
+     */
+    public static final String WAITING = "waiting";
+
+    /**
+     * A thread that is waiting for another thread to perform an action for up to a specified
+     * waiting time is in this state.
+     */
+    public static final String TIMED_WAITING = "timed_waiting";
+
+    /** A thread that has exited is in this state. */
+    public static final String TERMINATED = "terminated";
+
+    private JvmThreadStateValues() {}
+  }
+
+  public static final class SystemCpuStateValues {
+    /** user. */
+    public static final String USER = "user";
+
+    /** system. */
+    public static final String SYSTEM = "system";
+
+    /** nice. */
+    public static final String NICE = "nice";
+
+    /** idle. */
+    public static final String IDLE = "idle";
+
+    /** iowait. */
+    public static final String IOWAIT = "iowait";
+
+    /** interrupt. */
+    public static final String INTERRUPT = "interrupt";
+
+    /** steal. */
+    public static final String STEAL = "steal";
+
+    private SystemCpuStateValues() {}
+  }
+
+  public static final class SystemMemoryStateValues {
+    /** used. */
+    public static final String USED = "used";
+
+    /** free. */
+    public static final String FREE = "free";
+
+    /** shared. */
+    public static final String SHARED = "shared";
+
+    /** buffers. */
+    public static final String BUFFERS = "buffers";
+
+    /** cached. */
+    public static final String CACHED = "cached";
+
+    /**
+     * total.
+     *
+     * @deprecated this value has been removed as of 1.23.1 of the semantic conventions.
+     */
+    @Deprecated public static final String TOTAL = "total";
+
+    private SystemMemoryStateValues() {}
+  }
+
+  public static final class SystemPagingDirectionValues {
+    /** in. */
+    public static final String IN = "in";
+
+    /** out. */
+    public static final String OUT = "out";
+
+    private SystemPagingDirectionValues() {}
+  }
+
+  public static final class SystemPagingStateValues {
+    /** used. */
+    public static final String USED = "used";
+
+    /** free. */
+    public static final String FREE = "free";
+
+    private SystemPagingStateValues() {}
+  }
+
+  public static final class SystemPagingTypeValues {
+    /** major. */
+    public static final String MAJOR = "major";
+
+    /** minor. */
+    public static final String MINOR = "minor";
+
+    private SystemPagingTypeValues() {}
+  }
+
+  public static final class SystemDiskDirectionValues {
+    /** read. */
+    public static final String READ = "read";
+
+    /** write. */
+    public static final String WRITE = "write";
+
+    private SystemDiskDirectionValues() {}
+  }
+
+  public static final class SystemFilesystemStateValues {
+    /** used. */
+    public static final String USED = "used";
+
+    /** free. */
+    public static final String FREE = "free";
+
+    /** reserved. */
+    public static final String RESERVED = "reserved";
+
+    private SystemFilesystemStateValues() {}
+  }
+
+  public static final class SystemFilesystemTypeValues {
+    /** fat32. */
+    public static final String FAT32 = "fat32";
+
+    /** exfat. */
+    public static final String EXFAT = "exfat";
+
+    /** ntfs. */
+    public static final String NTFS = "ntfs";
+
+    /** refs. */
+    public static final String REFS = "refs";
+
+    /** hfsplus. */
+    public static final String HFSPLUS = "hfsplus";
+
+    /** ext4. */
+    public static final String EXT4 = "ext4";
+
+    private SystemFilesystemTypeValues() {}
+  }
+
+  public static final class SystemNetworkDirectionValues {
+    /** transmit. */
+    public static final String TRANSMIT = "transmit";
+
+    /** receive. */
+    public static final String RECEIVE = "receive";
+
+    private SystemNetworkDirectionValues() {}
+  }
+
+  public static final class SystemNetworkStateValues {
+    /** close. */
+    public static final String CLOSE = "close";
+
+    /** close_wait. */
+    public static final String CLOSE_WAIT = "close_wait";
+
+    /** closing. */
+    public static final String CLOSING = "closing";
+
+    /** delete. */
+    public static final String DELETE = "delete";
+
+    /** established. */
+    public static final String ESTABLISHED = "established";
+
+    /** fin_wait_1. */
+    public static final String FIN_WAIT_1 = "fin_wait_1";
+
+    /** fin_wait_2. */
+    public static final String FIN_WAIT_2 = "fin_wait_2";
+
+    /** last_ack. */
+    public static final String LAST_ACK = "last_ack";
+
+    /** listen. */
+    public static final String LISTEN = "listen";
+
+    /** syn_recv. */
+    public static final String SYN_RECV = "syn_recv";
+
+    /** syn_sent. */
+    public static final String SYN_SENT = "syn_sent";
+
+    /** time_wait. */
+    public static final String TIME_WAIT = "time_wait";
+
+    private SystemNetworkStateValues() {}
+  }
+
+  public static final class SystemProcessesStatusValues {
+    /** running. */
+    public static final String RUNNING = "running";
+
+    /** sleeping. */
+    public static final String SLEEPING = "sleeping";
+
+    /** stopped. */
+    public static final String STOPPED = "stopped";
+
+    /** defunct. */
+    public static final String DEFUNCT = "defunct";
+
+    private SystemProcessesStatusValues() {}
+  }
+
+  public static final class NetSockFamilyValues {
+    /** IPv4 address. */
+    public static final String INET = "inet";
+
+    /** IPv6 address. */
+    public static final String INET6 = "inet6";
+
+    /** Unix domain socket path. */
+    public static final String UNIX = "unix";
+
+    private NetSockFamilyValues() {}
+  }
+
+  public static final class NetTransportValues {
+    /** ip_tcp. */
+    public static final String IP_TCP = "ip_tcp";
+
+    /** ip_udp. */
+    public static final String IP_UDP = "ip_udp";
+
+    /** Named or anonymous pipe. */
+    public static final String PIPE = "pipe";
+
+    /** In-process communication. */
+    public static final String INPROC = "inproc";
+
+    /** Something else (non IP-based). */
+    public static final String OTHER = "other";
+
+    private NetTransportValues() {}
+  }
+
+  public static final class HttpRequestMethodValues {
+    /** CONNECT method. */
+    public static final String CONNECT = "CONNECT";
+
+    /** DELETE method. */
+    public static final String DELETE = "DELETE";
+
+    /** GET method. */
+    public static final String GET = "GET";
+
+    /** HEAD method. */
+    public static final String HEAD = "HEAD";
+
+    /** OPTIONS method. */
+    public static final String OPTIONS = "OPTIONS";
+
+    /** PATCH method. */
+    public static final String PATCH = "PATCH";
+
+    /** POST method. */
+    public static final String POST = "POST";
+
+    /** PUT method. */
+    public static final String PUT = "PUT";
+
+    /** TRACE method. */
+    public static final String TRACE = "TRACE";
+
+    /** Any HTTP method that the instrumentation has no prior knowledge of. */
+    public static final String OTHER = "_OTHER";
+
+    private HttpRequestMethodValues() {}
+  }
+
+  public static final class MessagingOperationValues {
+    /**
+     * One or more messages are provided for publishing to an intermediary. If a single message is
+     * published, the context of the &#34;Publish&#34; span can be used as the creation context and
+     * no &#34;Create&#34; span needs to be created.
+     */
+    public static final String PUBLISH = "publish";
+
+    /**
+     * A message is created. &#34;Create&#34; spans always refer to a single message and are used to
+     * provide a unique creation context for messages in batch publishing scenarios.
+     */
+    public static final String CREATE = "create";
+
+    /**
+     * One or more messages are requested by a consumer. This operation refers to pull-based
+     * scenarios, where consumers explicitly call methods of messaging SDKs to receive messages.
+     */
+    public static final String RECEIVE = "receive";
+
+    /**
+     * One or more messages are passed to a consumer. This operation refers to push-based scenarios,
+     * where consumer register callbacks which get called by messaging SDKs.
+     */
+    public static final String DELIVER = "deliver";
+
+    /**
+     * process.
+     *
+     * @deprecated this value has been removed as of 1.23.1 of the semantic conventions.
+     */
+    @Deprecated public static final String PROCESS = "process";
+
+    private MessagingOperationValues() {}
+  }
+
+  public static final class MessagingRocketmqConsumptionModelValues {
+    /** Clustering consumption model. */
+    public static final String CLUSTERING = "clustering";
+
+    /** Broadcasting consumption model. */
+    public static final String BROADCASTING = "broadcasting";
+
+    private MessagingRocketmqConsumptionModelValues() {}
+  }
+
+  public static final class MessagingRocketmqMessageTypeValues {
+    /** Normal message. */
+    public static final String NORMAL = "normal";
+
+    /** FIFO message. */
+    public static final String FIFO = "fifo";
+
+    /** Delay message. */
+    public static final String DELAY = "delay";
+
+    /** Transaction message. */
+    public static final String TRANSACTION = "transaction";
+
+    private MessagingRocketmqMessageTypeValues() {}
+  }
+
+  public static final class NetworkConnectionSubtypeValues {
+    /** GPRS. */
+    public static final String GPRS = "gprs";
+
+    /** EDGE. */
+    public static final String EDGE = "edge";
+
+    /** UMTS. */
+    public static final String UMTS = "umts";
+
+    /** CDMA. */
+    public static final String CDMA = "cdma";
+
+    /** EVDO Rel. 0. */
+    public static final String EVDO_0 = "evdo_0";
+
+    /** EVDO Rev. A. */
+    public static final String EVDO_A = "evdo_a";
+
+    /** CDMA2000 1XRTT. */
+    public static final String CDMA2000_1XRTT = "cdma2000_1xrtt";
+
+    /** HSDPA. */
+    public static final String HSDPA = "hsdpa";
+
+    /** HSUPA. */
+    public static final String HSUPA = "hsupa";
+
+    /** HSPA. */
+    public static final String HSPA = "hspa";
+
+    /** IDEN. */
+    public static final String IDEN = "iden";
+
+    /** EVDO Rev. B. */
+    public static final String EVDO_B = "evdo_b";
+
+    /** LTE. */
+    public static final String LTE = "lte";
+
+    /** EHRPD. */
+    public static final String EHRPD = "ehrpd";
+
+    /** HSPAP. */
+    public static final String HSPAP = "hspap";
+
+    /** GSM. */
+    public static final String GSM = "gsm";
+
+    /** TD-SCDMA. */
+    public static final String TD_SCDMA = "td_scdma";
+
+    /** IWLAN. */
+    public static final String IWLAN = "iwlan";
+
+    /** 5G NR (New Radio). */
+    public static final String NR = "nr";
+
+    /** 5G NRNSA (New Radio Non-Standalone). */
+    public static final String NRNSA = "nrnsa";
+
+    /** LTE CA. */
+    public static final String LTE_CA = "lte_ca";
+
+    private NetworkConnectionSubtypeValues() {}
+  }
+
+  public static final class NetworkConnectionTypeValues {
+    /** wifi. */
+    public static final String WIFI = "wifi";
+
+    /** wired. */
+    public static final String WIRED = "wired";
+
+    /** cell. */
+    public static final String CELL = "cell";
+
+    /** unavailable. */
+    public static final String UNAVAILABLE = "unavailable";
+
+    /** unknown. */
+    public static final String UNKNOWN = "unknown";
+
+    private NetworkConnectionTypeValues() {}
+  }
+
+  public static final class NetworkTransportValues {
+    /** TCP. */
+    public static final String TCP = "tcp";
+
+    /** UDP. */
+    public static final String UDP = "udp";
+
+    /** Named or anonymous pipe. */
+    public static final String PIPE = "pipe";
+
+    /** Unix domain socket. */
+    public static final String UNIX = "unix";
+
+    private NetworkTransportValues() {}
+  }
+
+  public static final class NetworkTypeValues {
+    /** IPv4. */
+    public static final String IPV4 = "ipv4";
+
+    /** IPv6. */
+    public static final String IPV6 = "ipv6";
+
+    private NetworkTypeValues() {}
+  }
+
+  public static final class RpcConnectRpcErrorCodeValues {
+    /** cancelled. */
+    public static final String CANCELLED = "cancelled";
+
+    /** unknown. */
+    public static final String UNKNOWN = "unknown";
+
+    /** invalid_argument. */
+    public static final String INVALID_ARGUMENT = "invalid_argument";
+
+    /** deadline_exceeded. */
+    public static final String DEADLINE_EXCEEDED = "deadline_exceeded";
+
+    /** not_found. */
+    public static final String NOT_FOUND = "not_found";
+
+    /** already_exists. */
+    public static final String ALREADY_EXISTS = "already_exists";
+
+    /** permission_denied. */
+    public static final String PERMISSION_DENIED = "permission_denied";
+
+    /** resource_exhausted. */
+    public static final String RESOURCE_EXHAUSTED = "resource_exhausted";
+
+    /** failed_precondition. */
+    public static final String FAILED_PRECONDITION = "failed_precondition";
+
+    /** aborted. */
+    public static final String ABORTED = "aborted";
+
+    /** out_of_range. */
+    public static final String OUT_OF_RANGE = "out_of_range";
+
+    /** unimplemented. */
+    public static final String UNIMPLEMENTED = "unimplemented";
+
+    /** internal. */
+    public static final String INTERNAL = "internal";
+
+    /** unavailable. */
+    public static final String UNAVAILABLE = "unavailable";
+
+    /** data_loss. */
+    public static final String DATA_LOSS = "data_loss";
+
+    /** unauthenticated. */
+    public static final String UNAUTHENTICATED = "unauthenticated";
+
+    private RpcConnectRpcErrorCodeValues() {}
+  }
+
+  public static final class RpcGrpcStatusCodeValues {
+    /** OK. */
+    public static final long OK = 0;
+
+    /** CANCELLED. */
+    public static final long CANCELLED = 1;
+
+    /** UNKNOWN. */
+    public static final long UNKNOWN = 2;
+
+    /** INVALID_ARGUMENT. */
+    public static final long INVALID_ARGUMENT = 3;
+
+    /** DEADLINE_EXCEEDED. */
+    public static final long DEADLINE_EXCEEDED = 4;
+
+    /** NOT_FOUND. */
+    public static final long NOT_FOUND = 5;
+
+    /** ALREADY_EXISTS. */
+    public static final long ALREADY_EXISTS = 6;
+
+    /** PERMISSION_DENIED. */
+    public static final long PERMISSION_DENIED = 7;
+
+    /** RESOURCE_EXHAUSTED. */
+    public static final long RESOURCE_EXHAUSTED = 8;
+
+    /** FAILED_PRECONDITION. */
+    public static final long FAILED_PRECONDITION = 9;
+
+    /** ABORTED. */
+    public static final long ABORTED = 10;
+
+    /** OUT_OF_RANGE. */
+    public static final long OUT_OF_RANGE = 11;
+
+    /** UNIMPLEMENTED. */
+    public static final long UNIMPLEMENTED = 12;
+
+    /** INTERNAL. */
+    public static final long INTERNAL = 13;
+
+    /** UNAVAILABLE. */
+    public static final long UNAVAILABLE = 14;
+
+    /** DATA_LOSS. */
+    public static final long DATA_LOSS = 15;
+
+    /** UNAUTHENTICATED. */
+    public static final long UNAUTHENTICATED = 16;
+
+    private RpcGrpcStatusCodeValues() {}
+  }
+
+  public static final class RpcSystemValues {
+    /** gRPC. */
+    public static final String GRPC = "grpc";
+
+    /** Java RMI. */
+    public static final String JAVA_RMI = "java_rmi";
+
+    /** .NET WCF. */
+    public static final String DOTNET_WCF = "dotnet_wcf";
+
+    /** Apache Dubbo. */
+    public static final String APACHE_DUBBO = "apache_dubbo";
+
+    /** Connect RPC. */
+    public static final String CONNECT_RPC = "connect_rpc";
+
+    private RpcSystemValues() {}
+  }
+
+  public static final class OpentracingRefTypeValues {
+    /** The parent Span depends on the child Span in some capacity. */
+    public static final String CHILD_OF = "child_of";
+
+    /** The parent Span doesn&#39;t depend in any way on the result of the child Span. */
+    public static final String FOLLOWS_FROM = "follows_from";
+
+    private OpentracingRefTypeValues() {}
+  }
+
+  public static final class DbSystemValues {
+    /** Some other SQL database. Fallback only. See notes. */
+    public static final String OTHER_SQL = "other_sql";
+
+    /** Microsoft SQL Server. */
+    public static final String MSSQL = "mssql";
+
+    /** Microsoft SQL Server Compact. */
+    public static final String MSSQLCOMPACT = "mssqlcompact";
+
+    /** MySQL. */
+    public static final String MYSQL = "mysql";
+
+    /** Oracle Database. */
+    public static final String ORACLE = "oracle";
+
+    /** IBM Db2. */
+    public static final String DB2 = "db2";
+
+    /** PostgreSQL. */
+    public static final String POSTGRESQL = "postgresql";
+
+    /** Amazon Redshift. */
+    public static final String REDSHIFT = "redshift";
+
+    /** Apache Hive. */
+    public static final String HIVE = "hive";
+
+    /** Cloudscape. */
+    public static final String CLOUDSCAPE = "cloudscape";
+
+    /** HyperSQL DataBase. */
+    public static final String HSQLDB = "hsqldb";
+
+    /** Progress Database. */
+    public static final String PROGRESS = "progress";
+
+    /** SAP MaxDB. */
+    public static final String MAXDB = "maxdb";
+
+    /** SAP HANA. */
+    public static final String HANADB = "hanadb";
+
+    /** Ingres. */
+    public static final String INGRES = "ingres";
+
+    /** FirstSQL. */
+    public static final String FIRSTSQL = "firstsql";
+
+    /** EnterpriseDB. */
+    public static final String EDB = "edb";
+
+    /** InterSystems Caché. */
+    public static final String CACHE = "cache";
+
+    /** Adabas (Adaptable Database System). */
+    public static final String ADABAS = "adabas";
+
+    /** Firebird. */
+    public static final String FIREBIRD = "firebird";
+
+    /** Apache Derby. */
+    public static final String DERBY = "derby";
+
+    /** FileMaker. */
+    public static final String FILEMAKER = "filemaker";
+
+    /** Informix. */
+    public static final String INFORMIX = "informix";
+
+    /** InstantDB. */
+    public static final String INSTANTDB = "instantdb";
+
+    /** InterBase. */
+    public static final String INTERBASE = "interbase";
+
+    /** MariaDB. */
+    public static final String MARIADB = "mariadb";
+
+    /** Netezza. */
+    public static final String NETEZZA = "netezza";
+
+    /** Pervasive PSQL. */
+    public static final String PERVASIVE = "pervasive";
+
+    /** PointBase. */
+    public static final String POINTBASE = "pointbase";
+
+    /** SQLite. */
+    public static final String SQLITE = "sqlite";
+
+    /** Sybase. */
+    public static final String SYBASE = "sybase";
+
+    /** Teradata. */
+    public static final String TERADATA = "teradata";
+
+    /** Vertica. */
+    public static final String VERTICA = "vertica";
+
+    /** H2. */
+    public static final String H2 = "h2";
+
+    /** ColdFusion IMQ. */
+    public static final String COLDFUSION = "coldfusion";
+
+    /** Apache Cassandra. */
+    public static final String CASSANDRA = "cassandra";
+
+    /** Apache HBase. */
+    public static final String HBASE = "hbase";
+
+    /** MongoDB. */
+    public static final String MONGODB = "mongodb";
+
+    /** Redis. */
+    public static final String REDIS = "redis";
+
+    /** Couchbase. */
+    public static final String COUCHBASE = "couchbase";
+
+    /** CouchDB. */
+    public static final String COUCHDB = "couchdb";
+
+    /** Microsoft Azure Cosmos DB. */
+    public static final String COSMOSDB = "cosmosdb";
+
+    /** Amazon DynamoDB. */
+    public static final String DYNAMODB = "dynamodb";
+
+    /** Neo4j. */
+    public static final String NEO4J = "neo4j";
+
+    /** Apache Geode. */
+    public static final String GEODE = "geode";
+
+    /** Elasticsearch. */
+    public static final String ELASTICSEARCH = "elasticsearch";
+
+    /** Memcached. */
+    public static final String MEMCACHED = "memcached";
+
+    /** CockroachDB. */
+    public static final String COCKROACHDB = "cockroachdb";
+
+    /** OpenSearch. */
+    public static final String OPENSEARCH = "opensearch";
+
+    /** ClickHouse. */
+    public static final String CLICKHOUSE = "clickhouse";
+
+    /** Cloud Spanner. */
+    public static final String SPANNER = "spanner";
+
+    /** Trino. */
+    public static final String TRINO = "trino";
+
+    private DbSystemValues() {}
+  }
+
+  public static final class DbCassandraConsistencyLevelValues {
+    /** all. */
+    public static final String ALL = "all";
+
+    /** each_quorum. */
+    public static final String EACH_QUORUM = "each_quorum";
+
+    /** quorum. */
+    public static final String QUORUM = "quorum";
+
+    /** local_quorum. */
+    public static final String LOCAL_QUORUM = "local_quorum";
+
+    /** one. */
+    public static final String ONE = "one";
+
+    /** two. */
+    public static final String TWO = "two";
+
+    /** three. */
+    public static final String THREE = "three";
+
+    /** local_one. */
+    public static final String LOCAL_ONE = "local_one";
+
+    /** any. */
+    public static final String ANY = "any";
+
+    /** serial. */
+    public static final String SERIAL = "serial";
+
+    /** local_serial. */
+    public static final String LOCAL_SERIAL = "local_serial";
+
+    private DbCassandraConsistencyLevelValues() {}
+  }
+
+  public static final class DbCosmosdbConnectionModeValues {
+    /** Gateway (HTTP) connections mode. */
+    public static final String GATEWAY = "gateway";
+
+    /** Direct connection. */
+    public static final String DIRECT = "direct";
+
+    private DbCosmosdbConnectionModeValues() {}
+  }
+
+  public static final class DbCosmosdbOperationTypeValues {
+    /** invalid. */
+    public static final String INVALID = "Invalid";
+
+    /** create. */
+    public static final String CREATE = "Create";
+
+    /** patch. */
+    public static final String PATCH = "Patch";
+
+    /** read. */
+    public static final String READ = "Read";
+
+    /** read_feed. */
+    public static final String READ_FEED = "ReadFeed";
+
+    /** delete. */
+    public static final String DELETE = "Delete";
+
+    /** replace. */
+    public static final String REPLACE = "Replace";
+
+    /** execute. */
+    public static final String EXECUTE = "Execute";
+
+    /** query. */
+    public static final String QUERY = "Query";
+
+    /** head. */
+    public static final String HEAD = "Head";
+
+    /** head_feed. */
+    public static final String HEAD_FEED = "HeadFeed";
+
+    /** upsert. */
+    public static final String UPSERT = "Upsert";
+
+    /** batch. */
+    public static final String BATCH = "Batch";
+
+    /** query_plan. */
+    public static final String QUERY_PLAN = "QueryPlan";
+
+    /** execute_javascript. */
+    public static final String EXECUTE_JAVASCRIPT = "ExecuteJavaScript";
+
+    private DbCosmosdbOperationTypeValues() {}
+  }
+
+  public static final class OtelStatusCodeValues {
+    /**
+     * The operation has been validated by an Application developer or Operator to have completed
+     * successfully.
+     */
+    public static final String OK = "OK";
+
+    /** The operation contains an error. */
+    public static final String ERROR = "ERROR";
+
+    private OtelStatusCodeValues() {}
+  }
+
+  public static final class FaasDocumentOperationValues {
+    /** When a new object is created. */
+    public static final String INSERT = "insert";
+
+    /** When an object is modified. */
+    public static final String EDIT = "edit";
+
+    /** When an object is deleted. */
+    public static final String DELETE = "delete";
+
+    private FaasDocumentOperationValues() {}
+  }
+
+  public static final class GraphqlOperationTypeValues {
+    /** GraphQL query. */
+    public static final String QUERY = "query";
+
+    /** GraphQL mutation. */
+    public static final String MUTATION = "mutation";
+
+    /** GraphQL subscription. */
+    public static final String SUBSCRIPTION = "subscription";
+
+    private GraphqlOperationTypeValues() {}
+  }
+
+  public static final class MessageTypeValues {
+    /** sent. */
+    public static final String SENT = "SENT";
+
+    /** received. */
+    public static final String RECEIVED = "RECEIVED";
+
+    private MessageTypeValues() {}
+  }
+
+  // Manually defined and not YET in the YAML
+  /**
+   * The name of an event describing an exception.
+   *
+   * <p>Typically an event with that name should not be manually created. Instead {@link
+   * io.opentelemetry.api.trace.Span#recordException(Throwable)} should be used.
+   */
+  public static final String EXCEPTION_EVENT_NAME = "exception";
+
+  /**
+   * The name of the keyspace being accessed.
+   *
+   * @deprecated this item has been removed as of 1.8.0 of the semantic conventions. Please use
+   *     {@link SemanticAttributes#DB_NAME} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> DB_CASSANDRA_KEYSPACE =
+      stringKey("db.cassandra.keyspace");
+
+  /**
+   * The <a href="https://hbase.apache.org/book.html#_namespace">HBase namespace</a> being accessed.
+   *
+   * @deprecated this item has been removed as of 1.8.0 of the semantic conventions. Please use
+   *     {@link SemanticAttributes#DB_NAME} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> DB_HBASE_NAMESPACE = stringKey("db.hbase.namespace");
+
+  /**
+   * The size of the uncompressed request payload body after transport decoding. Not set if
+   * transport encoding not used.
+   *
+   * @deprecated this item has been removed as of 1.13.0 of the semantic conventions. Please use
+   *     {@link SemanticAttributes#HTTP_REQUEST_CONTENT_LENGTH} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED =
+      longKey("http.request_content_length_uncompressed");
+
+  /**
+   * @deprecated This item has been removed as of 1.13.0 of the semantic conventions. Please use
+   *     {@link SemanticAttributes#HTTP_RESPONSE_CONTENT_LENGTH} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED =
+      longKey("http.response_content_length_uncompressed");
+
+  /**
+   * @deprecated This item has been removed as of 1.13.0 of the semantic conventions. Please use
+   *     {@link SemanticAttributes#NET_HOST_NAME} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> HTTP_SERVER_NAME = stringKey("http.server_name");
+
+  /**
+   * @deprecated This item has been removed as of 1.13.0 of the semantic conventions. Please use
+   *     {@link SemanticAttributes#NET_HOST_NAME} instead.
+   */
+  @Deprecated public static final AttributeKey<String> HTTP_HOST = stringKey("http.host");
+
+  /**
+   * @deprecated This item has been removed as of 1.13.0 of the semantic conventions. Please use
+   *     {@link SemanticAttributes#NET_SOCK_PEER_ADDR} instead.
+   */
+  @Deprecated public static final AttributeKey<String> NET_PEER_IP = stringKey("net.peer.ip");
+
+  /**
+   * @deprecated This item has been removed as of 1.13.0 of the semantic conventions. Please use
+   *     {@link SemanticAttributes#NET_SOCK_HOST_ADDR} instead.
+   */
+  @Deprecated public static final AttributeKey<String> NET_HOST_IP = stringKey("net.host.ip");
+
+  /**
+   * The ordinal number of request re-sending attempt.
+   *
+   * @deprecated This item has been removed as of 1.15.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#HTTP_RESEND_COUNT} instead.
+   */
+  @Deprecated public static final AttributeKey<Long> HTTP_RETRY_COUNT = longKey("http.retry_count");
+
+  /**
+   * A string identifying the messaging system.
+   *
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#MESSAGING_DESTINATION_NAME} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> MESSAGING_DESTINATION =
+      stringKey("messaging.destination");
+
+  /**
+   * A boolean that is true if the message destination is temporary.
+   *
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#MESSAGING_DESTINATION_TEMPORARY} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Boolean> MESSAGING_TEMP_DESTINATION =
+      booleanKey("messaging.temp_destination");
+
+  /**
+   * The name of the transport protocol.
+   *
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#NET_PROTOCOL_NAME} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> MESSAGING_PROTOCOL = stringKey("messaging.protocol");
+
+  /**
+   * The version of the transport protocol.
+   *
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#NET_PROTOCOL_VERSION} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> MESSAGING_PROTOCOL_VERSION =
+      stringKey("messaging.protocol_version");
+
+  /**
+   * Connection string.
+   *
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. There is no
+   *     replacement.
+   */
+  @Deprecated public static final AttributeKey<String> MESSAGING_URL = stringKey("messaging.url");
+
+  /**
+   * The <a href="#conversations">conversation ID</a> identifying the conversation to which the
+   * message belongs, represented as a string. Sometimes called &quot;Correlation ID&quot;.
+   *
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#MESSAGING_MESSAGE_CONVERSATION_ID} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> MESSAGING_CONVERSATION_ID =
+      stringKey("messaging.conversation_id");
+
+  /**
+   * RabbitMQ message routing key.
+   *
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> MESSAGING_RABBITMQ_ROUTING_KEY =
+      stringKey("messaging.rabbitmq.routing_key");
+
+  /**
+   * Partition the message is received from.
+   *
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#MESSAGING_KAFKA_SOURCE_PARTITION} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> MESSAGING_KAFKA_PARTITION =
+      longKey("messaging.kafka.partition");
+
+  /**
+   * A boolean that is true if the message is a tombstone.
+   *
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#MESSAGING_KAFKA_MESSAGE_TOMBSTONE} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Boolean> MESSAGING_KAFKA_TOMBSTONE =
+      booleanKey("messaging.kafka.tombstone");
+
+  /**
+   * The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
+   *
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> MESSAGING_ROCKETMQ_DELIVERY_TIMESTAMP =
+      longKey("messaging.rocketmq.delivery_timestamp");
+
+  /**
+   * The delay time level for delay message, which determines the message delay time.
+   *
+   * @deprecated This item has been removed as of 1.17.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#MESSAGING_ROCKETMQ_MESSAGE_DELAY_TIME_LEVEL} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> MESSAGING_ROCKETMQ_DELAY_TIME_LEVEL =
+      longKey("messaging.rocketmq.delay_time_level");
+
+  /**
+   * The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP).
+   *
+   * @deprecated This item has been moved, use {@link
+   *     io.opentelemetry.semconv.ResourceAttributes#OTEL_SCOPE_NAME} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_SCOPE_NAME = stringKey("otel.scope.name");
+
+  /**
+   * The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP).
+   *
+   * @deprecated This item has been moved, use {@link
+   *     io.opentelemetry.semconv.ResourceAttributes#OTEL_SCOPE_VERSION} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_SCOPE_VERSION = stringKey("otel.scope.version");
+
+  /**
+   * The execution ID of the current function execution.
+   *
+   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use
+   *     {@link SemanticAttributes#FAAS_INVOCATION_ID} instead.
+   */
+  @Deprecated public static final AttributeKey<String> FAAS_EXECUTION = stringKey("faas.execution");
+
+  /**
+   * Value of the <a href="https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent">HTTP
+   * User-Agent</a> header sent by the client.
+   *
+   * @deprecated This item has been renamed in 1.19.0 version of the semantic conventions. Use
+   *     {@link SemanticAttributes#USER_AGENT_ORIGINAL} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> HTTP_USER_AGENT = stringKey("http.user_agent");
+
+  /**
+   * Deprecated.
+   *
+   * @deprecated Deprecated, use the {@link
+   *     io.opentelemetry.semconv.ResourceAttributes#OTEL_SCOPE_NAME} attribute.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_LIBRARY_NAME = stringKey("otel.library.name");
+
+  /**
+   * Deprecated.
+   *
+   * @deprecated Deprecated, use the {@link
+   *     io.opentelemetry.semconv.ResourceAttributes#OTEL_SCOPE_VERSION} attribute.
+   */
+  @Deprecated
+  public static final AttributeKey<String> OTEL_LIBRARY_VERSION = stringKey("otel.library.version");
+
+  /**
+   * Kind of HTTP protocol used.
+   *
+   * @deprecated This item has been removed as of 1.20.0 of the semantic conventions.
+   */
+  @Deprecated public static final AttributeKey<String> HTTP_FLAVOR = stringKey("http.flavor");
+
+  /**
+   * Enum definitions for {@link #HTTP_FLAVOR}.
+   *
+   * @deprecated This item has been removed as of 1.20.0 of the semantic conventions.
+   */
+  @Deprecated
+  public static final class HttpFlavorValues {
+    /** HTTP/1.0. */
+    public static final String HTTP_1_0 = "1.0";
+
+    /** HTTP/1.1. */
+    public static final String HTTP_1_1 = "1.1";
+
+    /** HTTP/2. */
+    public static final String HTTP_2_0 = "2.0";
+
+    /** HTTP/3. */
+    public static final String HTTP_3_0 = "3.0";
+
+    /** SPDY protocol. */
+    public static final String SPDY = "SPDY";
+
+    /** QUIC protocol. */
+    public static final String QUIC = "QUIC";
+
+    private HttpFlavorValues() {}
+  }
+
+  /**
+   * Application layer protocol used. The value SHOULD be normalized to lowercase.
+   *
+   * @deprecated This item has been removed as of 1.20.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#NET_PROTOCOL_NAME} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_APP_PROTOCOL_NAME =
+      stringKey("net.app.protocol.name");
+
+  /**
+   * Version of the application layer protocol used. See note below.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>{@code net.app.protocol.version} refers to the version of the protocol used and might be
+   *       different from the protocol client's version. If the HTTP client used has a version of
+   *       {@code 0.27.2}, but sends HTTP version {@code 1.1}, this attribute should be set to
+   *       {@code 1.1}.
+   * </ul>
+   *
+   * @deprecated This item has been removed as of 1.20.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#NET_PROTOCOL_VERSION} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_APP_PROTOCOL_VERSION =
+      stringKey("net.app.protocol.version");
+
+  /**
+   * The kind of message destination.
+   *
+   * @deprecated This item has been removed as of 1.20.0 of the semantic conventions.
+   */
+  @Deprecated
+  public static final AttributeKey<String> MESSAGING_DESTINATION_KIND =
+      stringKey("messaging.destination.kind");
+
+  /**
+   * Enum values for {@link #MESSAGING_DESTINATION_KIND}.
+   *
+   * @deprecated This item has been removed as of 1.20.0 of the semantic conventions.
+   */
+  @Deprecated
+  public static final class MessagingDestinationKindValues {
+    /** A message sent to a queue. */
+    public static final String QUEUE = "queue";
+
+    /** A message sent to a topic. */
+    public static final String TOPIC = "topic";
+
+    private MessagingDestinationKindValues() {}
+  }
+
+  /**
+   * The kind of message source.
+   *
+   * @deprecated This item has been removed as of 1.20.0 of the semantic conventions.
+   */
+  @Deprecated
+  public static final AttributeKey<String> MESSAGING_SOURCE_KIND =
+      stringKey("messaging.source.kind");
+
+  /**
+   * Enum values for {@link #MESSAGING_SOURCE_KIND}.
+   *
+   * @deprecated This item has been removed as of 1.20.0 of the semantic conventions.
+   */
+  @Deprecated
+  public static final class MessagingSourceKindValues {
+    /** A message received from a queue. */
+    public static final String QUEUE = "queue";
+
+    /** A message received from a topic. */
+    public static final String TOPIC = "topic";
+
+    private MessagingSourceKindValues() {}
+  }
+
+  /**
+   * The internet connection type currently being used by the host.
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions. Use
+   *     {@link SemanticAttributes#NETWORK_CONNECTION_TYPE} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_HOST_CONNECTION_TYPE =
+      stringKey("net.host.connection.type");
+
+  /**
+   * This describes more details regarding the connection.type. It may be the type of cell
+   * technology connection, but it could be used for describing details about a wifi connection.
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions. Use
+   *     {@link SemanticAttributes#NETWORK_CONNECTION_SUBTYPE} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_HOST_CONNECTION_SUBTYPE =
+      stringKey("net.host.connection.subtype");
+
+  /**
+   * The name of the mobile carrier.
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions. Use
+   *     {@link SemanticAttributes#NETWORK_CARRIER_NAME} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_HOST_CARRIER_NAME =
+      stringKey("net.host.carrier.name");
+
+  /**
+   * The mobile carrier country code.
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions. Use
+   *     {@link SemanticAttributes#NETWORK_CARRIER_MCC} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_HOST_CARRIER_MCC = stringKey("net.host.carrier.mcc");
+
+  /**
+   * The mobile carrier network code.
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions. Use
+   *     {@link SemanticAttributes#NETWORK_CARRIER_MNC} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_HOST_CARRIER_MNC = stringKey("net.host.carrier.mnc");
+
+  /**
+   * The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions. Use
+   *     {@link SemanticAttributes#NETWORK_CARRIER_ICC} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> NET_HOST_CARRIER_ICC = stringKey("net.host.carrier.icc");
+
+  /**
+   * The IP address of the original client behind all proxies, if known (e.g. from <a
+   * href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For">X-Forwarded-For</a>).
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This is not necessarily the same as {@code net.sock.peer.addr}, which would identify the
+   *       network-level peer, which may be a proxy.
+   *   <li>This attribute should be set when a source of information different from the one used for
+   *       {@code net.sock.peer.addr}, is available even if that other source just confirms the same
+   *       value as {@code net.sock.peer.addr}. Rationale: For {@code net.sock.peer.addr}, one
+   *       typically does not know if it comes from a proxy, reverse proxy, or the actual client.
+   *       Setting {@code http.client_ip} when it's the same as {@code net.sock.peer.addr} means
+   *       that one is at least somewhat confident that the address is not that of the closest
+   *       proxy.
+   * </ul>
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions. Use
+   *     {@link SemanticAttributes#CLIENT_ADDRESS} instead.
+   */
+  @Deprecated public static final AttributeKey<String> HTTP_CLIENT_IP = stringKey("http.client_ip");
+
+  /**
+   * The message source name.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Source name SHOULD uniquely identify a specific queue, topic, or other entity within the
+   *       broker. If the broker does not have such notion, the source name SHOULD uniquely identify
+   *       the broker.
+   * </ul>
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions.
+   */
+  @Deprecated
+  public static final AttributeKey<String> MESSAGING_SOURCE_NAME =
+      stringKey("messaging.source.name");
+
+  /**
+   * Low cardinality representation of the messaging source name.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Source names could be constructed from templates. An example would be a source name
+   *       involving a user name or product id. Although the source name in this case is of high
+   *       cardinality, the underlying template is of low cardinality and can be effectively used
+   *       for grouping and aggregation.
+   * </ul>
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions.
+   */
+  @Deprecated
+  public static final AttributeKey<String> MESSAGING_SOURCE_TEMPLATE =
+      stringKey("messaging.source.template");
+
+  /**
+   * A boolean that is true if the message source is temporary and might not exist anymore after
+   * messages are processed.
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions.
+   */
+  @Deprecated
+  public static final AttributeKey<Boolean> MESSAGING_SOURCE_TEMPORARY =
+      booleanKey("messaging.source.temporary");
+
+  /**
+   * A boolean that is true if the message source is anonymous (could be unnamed or have
+   * auto-generated name).
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions.
+   */
+  @Deprecated
+  public static final AttributeKey<Boolean> MESSAGING_SOURCE_ANONYMOUS =
+      booleanKey("messaging.source.anonymous");
+
+  /**
+   * The identifier for the consumer receiving a message. For Kafka, set it to {@code
+   * {messaging.kafka.consumer.group} - {messaging.kafka.client_id}}, if both are present, or only
+   * {@code messaging.kafka.consumer.group}. For brokers, such as RabbitMQ and Artemis, set it to
+   * the {@code client_id} of the client consuming the message.
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions. See
+   *     {@link SemanticAttributes#MESSAGING_CLIENT_ID}.
+   */
+  @Deprecated
+  public static final AttributeKey<String> MESSAGING_CONSUMER_ID =
+      stringKey("messaging.consumer.id");
+
+  /**
+   * Client Id for the Consumer or Producer that is handling the message.
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions. See
+   *     {@link SemanticAttributes#MESSAGING_CLIENT_ID}.
+   */
+  @Deprecated
+  public static final AttributeKey<String> MESSAGING_KAFKA_CLIENT_ID =
+      stringKey("messaging.kafka.client_id");
+
+  /**
+   * Partition the message is received from.
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> MESSAGING_KAFKA_SOURCE_PARTITION =
+      longKey("messaging.kafka.source.partition");
+
+  /**
+   * The unique identifier for each client.
+   *
+   * @deprecated This item has been removed in 1.21.0 version of the semantic conventions. See
+   *     {@link SemanticAttributes#MESSAGING_CLIENT_ID}.
+   */
+  @Deprecated
+  public static final AttributeKey<String> MESSAGING_ROCKETMQ_CLIENT_ID =
+      stringKey("messaging.rocketmq.client_id");
+
+  /**
+   * Enum values for {@link #NET_HOST_CONNECTION_TYPE}.
+   *
+   * @deprecated This item has been removed as of 1.21.0 of the semantic conventions. Use {@link
+   *     NetworkConnectionTypeValues} instead.
+   */
+  @Deprecated
+  public static final class NetHostConnectionTypeValues {
+    /** wifi. */
+    public static final String WIFI = "wifi";
+
+    /** wired. */
+    public static final String WIRED = "wired";
+
+    /** cell. */
+    public static final String CELL = "cell";
+
+    /** unavailable. */
+    public static final String UNAVAILABLE = "unavailable";
+
+    /** unknown. */
+    public static final String UNKNOWN = "unknown";
+
+    private NetHostConnectionTypeValues() {}
+  }
+
+  /**
+   * Enum values for {@link #NET_HOST_CONNECTION_SUBTYPE}.
+   *
+   * @deprecated This item has been removed as of 1.21.0 of the semantic conventions. Use {@link
+   *     NetworkConnectionSubtypeValues} instead.
+   */
+  @Deprecated
+  public static final class NetHostConnectionSubtypeValues {
+    /** GPRS. */
+    public static final String GPRS = "gprs";
+
+    /** EDGE. */
+    public static final String EDGE = "edge";
+
+    /** UMTS. */
+    public static final String UMTS = "umts";
+
+    /** CDMA. */
+    public static final String CDMA = "cdma";
+
+    /** EVDO Rel. 0. */
+    public static final String EVDO_0 = "evdo_0";
+
+    /** EVDO Rev. A. */
+    public static final String EVDO_A = "evdo_a";
+
+    /** CDMA2000 1XRTT. */
+    public static final String CDMA2000_1XRTT = "cdma2000_1xrtt";
+
+    /** HSDPA. */
+    public static final String HSDPA = "hsdpa";
+
+    /** HSUPA. */
+    public static final String HSUPA = "hsupa";
+
+    /** HSPA. */
+    public static final String HSPA = "hspa";
+
+    /** IDEN. */
+    public static final String IDEN = "iden";
+
+    /** EVDO Rev. B. */
+    public static final String EVDO_B = "evdo_b";
+
+    /** LTE. */
+    public static final String LTE = "lte";
+
+    /** EHRPD. */
+    public static final String EHRPD = "ehrpd";
+
+    /** HSPAP. */
+    public static final String HSPAP = "hspap";
+
+    /** GSM. */
+    public static final String GSM = "gsm";
+
+    /** TD-SCDMA. */
+    public static final String TD_SCDMA = "td_scdma";
+
+    /** IWLAN. */
+    public static final String IWLAN = "iwlan";
+
+    /** 5G NR (New Radio). */
+    public static final String NR = "nr";
+
+    /** 5G NRNSA (New Radio Non-Standalone). */
+    public static final String NRNSA = "nrnsa";
+
+    /** LTE CA. */
+    public static final String LTE_CA = "lte_ca";
+
+    private NetHostConnectionSubtypeValues() {}
+  }
+
+  /**
+   * Immediate client peer port number.
+   *
+   * @deprecated This item has been renamed in 1.22.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#NETWORK_PEER_PORT} on server telemetry and {@link
+   *     SemanticAttributes#NETWORK_LOCAL_PORT} on client telemetry instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> CLIENT_SOCKET_PORT = longKey("client.socket.port");
+
+  /**
+   * Name of the memory pool.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Pool names are generally obtained via <a
+   *       href="https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()">MemoryPoolMXBean#getName()</a>.
+   * </ul>
+   *
+   * @deprecated This item has been renamed in 1.22.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#JVM_MEMORY_POOL_NAME} instead.
+   */
+  @Deprecated public static final AttributeKey<String> POOL = stringKey("pool");
+
+  /**
+   * The domain name of the source system.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>This value may be a host name, a fully qualified domain name, or another host naming
+   *       format.
+   * </ul>
+   *
+   * @deprecated This item has been removed in 1.22.0 of the semantic conventions.
+   */
+  @Deprecated public static final AttributeKey<String> SOURCE_DOMAIN = stringKey("source.domain");
+
+  /**
+   * Physical server IP address or Unix socket address. If set from the client, should simply use
+   * the socket's peer address, and not attempt to find any actual server IP (i.e., if set from
+   * client, this may represent some proxy server instead of the logical server).
+   *
+   * @deprecated This item has been renamed in 1.22.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#NETWORK_LOCAL_ADDRESS} on server telemetry and {@link
+   *     SemanticAttributes#NETWORK_PEER_ADDRESS} on client telemetry instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> SERVER_SOCKET_ADDRESS =
+      stringKey("server.socket.address");
+
+  /**
+   * The (uncompressed) size of the message payload in bytes. Also use this attribute if it is
+   * unknown whether the compressed or uncompressed payload size is reported.
+   *
+   * @deprecated This item has been renamed in 1.22.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#MESSAGING_MESSAGE_BODY_SIZE} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES =
+      longKey("messaging.message.payload_size_bytes");
+
+  /**
+   * The domain name of the destination system.
+   *
+   * @deprecated This item has been removed in 1.22.0 of the semantic conventions.
+   */
+  @Deprecated
+  public static final AttributeKey<String> DESTINATION_DOMAIN = stringKey("destination.domain");
+
+  /**
+   * The compressed size of the message payload in bytes.
+   *
+   * @deprecated This item has been removed in 1.22.0 of the semantic conventions.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES =
+      longKey("messaging.message.payload_compressed_size_bytes");
+
+  /**
+   * The domain name of an immediate peer.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Typically observed from the client side, and represents a proxy or other intermediary
+   *       domain name.
+   * </ul>
+   *
+   * @deprecated This item has been removed in 1.22.0 of the semantic conventions.
+   */
+  @Deprecated
+  public static final AttributeKey<String> SERVER_SOCKET_DOMAIN = stringKey("server.socket.domain");
+
+  /**
+   * The type of memory.
+   *
+   * @deprecated This item has been renamed in 1.22.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#JVM_MEMORY_TYPE} instead.
+   */
+  @Deprecated public static final AttributeKey<String> TYPE = stringKey("type");
+
+  /**
+   * Physical server port.
+   *
+   * @deprecated This item has been renamed in 1.22.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#NETWORK_LOCAL_PORT} on server telemetry and {@link
+   *     SemanticAttributes#NETWORK_PEER_PORT} on client telemetry instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> SERVER_SOCKET_PORT = longKey("server.socket.port");
+
+  /**
+   * Immediate client peer address - unix domain socket name, IPv4 or IPv6 address.
+   *
+   * @deprecated This item has been renamed in 1.22.0 of the semantic conventions. Use {@link
+   *     SemanticAttributes#NETWORK_PEER_ADDRESS} on server telemetry and {@link
+   *     SemanticAttributes#NETWORK_LOCAL_ADDRESS} on client telemetry instead.
+   */
+  @Deprecated
+  public static final AttributeKey<String> CLIENT_SOCKET_ADDRESS =
+      stringKey("client.socket.address");
+
+  /**
+   * @deprecated This item has been renamed as of 1.21.0 of the semantic conventions. Use {@link
+   *     JvmMemoryTypeValues} instead.
+   */
+  @Deprecated
+  public static final class TypeValues {
+    /** Heap memory. */
+    public static final String HEAP = "heap";
+
+    /** Non-heap memory. */
+    public static final String NON_HEAP = "non_heap";
+
+    private TypeValues() {}
+  }
+
+  /**
+   * Whether the thread is daemon or not.
+   *
+   * @deprecated This item has been renamed in 1.23.1 of the semantic conventions. Use {@link
+   *     SemanticAttributes#JVM_THREAD_DAEMON} instead.
+   */
+  @Deprecated public static final AttributeKey<Boolean> THREAD_DAEMON = booleanKey("thread.daemon");
+
+  /**
+   * The ordinal number of request resending attempt (for any reason, including redirects).
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>The resend count SHOULD be updated each time an HTTP request gets resent by the client,
+   *       regardless of what was the cause of the resending (e.g. redirection, authorization
+   *       failure, 503 Server Unavailable, network issues, or any other).
+   * </ul>
+   *
+   * @deprecated This item has been renamed in 1.23.1 of the semantic conventions. Use {@link
+   *     SemanticAttributes#HTTP_REQUEST_RESEND_COUNT} instead.
+   */
+  @Deprecated
+  public static final AttributeKey<Long> HTTP_RESEND_COUNT = longKey("http.resend_count");
+
+  private SemanticAttributes() {}
+}

--- a/semconv/src/main/java/io/opentelemetry/semconv/SemanticAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/SemanticAttributes.java
@@ -17,15 +17,15 @@ import io.opentelemetry.api.common.AttributeKey;
 import java.util.List;
 
 /**
- * @deprecated This class is deprecated and will be removed in a future release. It is only provided as a
- * convenience to help migration to the new semantic conventions classes structure that was introduced
- * in version 1.24.0.
+ * @deprecated This class is deprecated and will be removed in a future release. It is only provided
+ *     as a convenience to help migration to the new semantic conventions classes structure that was
+ *     introduced in version 1.24.0.
  */
 @Deprecated
 @SuppressWarnings("unused")
 public final class SemanticAttributes {
   /** The URL of the OpenTelemetry schema for these keys and values. */
-  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.23.1";
+  @Deprecated public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.23.1";
 
   /**
    * Client address - domain name if available without reverse DNS lookup; otherwise, IP address or
@@ -39,7 +39,7 @@ public final class SemanticAttributes {
    *       example proxies, if it's available.
    * </ul>
    */
-  public static final AttributeKey<String> CLIENT_ADDRESS = stringKey("client.address");
+  @Deprecated public static final AttributeKey<String> CLIENT_ADDRESS = stringKey("client.address");
 
   /**
    * Client port number.
@@ -52,7 +52,7 @@ public final class SemanticAttributes {
    *       example proxies, if it's available.
    * </ul>
    */
-  public static final AttributeKey<Long> CLIENT_PORT = longKey("client.port");
+  @Deprecated public static final AttributeKey<Long> CLIENT_PORT = longKey("client.port");
 
   /**
    * Destination address - domain name if available without reverse DNS lookup; otherwise, IP
@@ -66,10 +66,11 @@ public final class SemanticAttributes {
    *       intermediaries, for example proxies, if it's available.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> DESTINATION_ADDRESS = stringKey("destination.address");
 
   /** Destination port number */
-  public static final AttributeKey<Long> DESTINATION_PORT = longKey("destination.port");
+  @Deprecated public static final AttributeKey<Long> DESTINATION_PORT = longKey("destination.port");
 
   /**
    * Describes a class of error the operation ended with.
@@ -92,22 +93,24 @@ public final class SemanticAttributes {
    *       within the domain-specific set or not.
    * </ul>
    */
-  public static final AttributeKey<String> ERROR_TYPE = stringKey("error.type");
+  @Deprecated public static final AttributeKey<String> ERROR_TYPE = stringKey("error.type");
 
   /** The exception message. */
+  @Deprecated
   public static final AttributeKey<String> EXCEPTION_MESSAGE = stringKey("exception.message");
 
   /**
    * A stacktrace as a string in the natural representation for the language runtime. The
    * representation is to be determined and documented by each language SIG.
    */
+  @Deprecated
   public static final AttributeKey<String> EXCEPTION_STACKTRACE = stringKey("exception.stacktrace");
 
   /**
    * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of
    * the exception should be preferred over the static type in languages that support it.
    */
-  public static final AttributeKey<String> EXCEPTION_TYPE = stringKey("exception.type");
+  @Deprecated public static final AttributeKey<String> EXCEPTION_TYPE = stringKey("exception.type");
 
   /**
    * The name of the invoked function.
@@ -118,6 +121,7 @@ public final class SemanticAttributes {
    *   <li>SHOULD be equal to the {@code faas.name} resource attribute of the invoked function.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> FAAS_INVOKED_NAME = stringKey("faas.invoked_name");
 
   /**
@@ -129,6 +133,7 @@ public final class SemanticAttributes {
    *   <li>SHOULD be equal to the {@code cloud.provider} resource attribute of the invoked function.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> FAAS_INVOKED_PROVIDER =
       stringKey("faas.invoked_provider");
 
@@ -141,30 +146,31 @@ public final class SemanticAttributes {
    *   <li>SHOULD be equal to the {@code cloud.region} resource attribute of the invoked function.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> FAAS_INVOKED_REGION = stringKey("faas.invoked_region");
 
   /** Type of the trigger which caused this function invocation. */
-  public static final AttributeKey<String> FAAS_TRIGGER = stringKey("faas.trigger");
+  @Deprecated public static final AttributeKey<String> FAAS_TRIGGER = stringKey("faas.trigger");
 
   /**
    * The <a href="/docs/resource/README.md#service">{@code service.name}</a> of the remote service.
    * SHOULD be equal to the actual {@code service.name} resource attribute of the remote service if
    * any.
    */
-  public static final AttributeKey<String> PEER_SERVICE = stringKey("peer.service");
+  @Deprecated public static final AttributeKey<String> PEER_SERVICE = stringKey("peer.service");
 
   /**
    * Username or client_id extracted from the access token or <a
    * href="https://tools.ietf.org/html/rfc7235#section-4.2">Authorization</a> header in the inbound
    * request from outside the system.
    */
-  public static final AttributeKey<String> ENDUSER_ID = stringKey("enduser.id");
+  @Deprecated public static final AttributeKey<String> ENDUSER_ID = stringKey("enduser.id");
 
   /**
    * Actual/assumed role the client is making the request under extracted from token or application
    * security context.
    */
-  public static final AttributeKey<String> ENDUSER_ROLE = stringKey("enduser.role");
+  @Deprecated public static final AttributeKey<String> ENDUSER_ROLE = stringKey("enduser.role");
 
   /**
    * Scopes or granted authorities the client currently possesses extracted from token or
@@ -174,7 +180,7 @@ public final class SemanticAttributes {
    * href="http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html">SAML
    * 2.0 Assertion</a>.
    */
-  public static final AttributeKey<String> ENDUSER_SCOPE = stringKey("enduser.scope");
+  @Deprecated public static final AttributeKey<String> ENDUSER_SCOPE = stringKey("enduser.scope");
 
   /**
    * The domain identifies the business context for the events.
@@ -186,10 +192,10 @@ public final class SemanticAttributes {
    *       events.
    * </ul>
    */
-  public static final AttributeKey<String> EVENT_DOMAIN = stringKey("event.domain");
+  @Deprecated public static final AttributeKey<String> EVENT_DOMAIN = stringKey("event.domain");
 
   /** The name identifies the event. */
-  public static final AttributeKey<String> EVENT_NAME = stringKey("event.name");
+  @Deprecated public static final AttributeKey<String> EVENT_NAME = stringKey("event.name");
 
   /**
    * A unique identifier for the Log Record.
@@ -204,22 +210,24 @@ public final class SemanticAttributes {
    *       UUID) may be used as needed.
    * </ul>
    */
-  public static final AttributeKey<String> LOG_RECORD_UID = stringKey("log.record.uid");
+  @Deprecated public static final AttributeKey<String> LOG_RECORD_UID = stringKey("log.record.uid");
 
   /** The stream associated with the log. See below for a list of well-known values. */
-  public static final AttributeKey<String> LOG_IOSTREAM = stringKey("log.iostream");
+  @Deprecated public static final AttributeKey<String> LOG_IOSTREAM = stringKey("log.iostream");
 
   /** The basename of the file. */
-  public static final AttributeKey<String> LOG_FILE_NAME = stringKey("log.file.name");
+  @Deprecated public static final AttributeKey<String> LOG_FILE_NAME = stringKey("log.file.name");
 
   /** The basename of the file, with symlinks resolved. */
+  @Deprecated
   public static final AttributeKey<String> LOG_FILE_NAME_RESOLVED =
       stringKey("log.file.name_resolved");
 
   /** The full path to the file. */
-  public static final AttributeKey<String> LOG_FILE_PATH = stringKey("log.file.path");
+  @Deprecated public static final AttributeKey<String> LOG_FILE_PATH = stringKey("log.file.path");
 
   /** The full path to the file, with symlinks resolved. */
+  @Deprecated
   public static final AttributeKey<String> LOG_FILE_PATH_RESOLVED =
       stringKey("log.file.path_resolved");
 
@@ -235,7 +243,7 @@ public final class SemanticAttributes {
    *       documentation</a>, and from which the {@code OS terminology} column values are derived.
    * </ul>
    */
-  public static final AttributeKey<String> IOS_STATE = stringKey("ios.state");
+  @Deprecated public static final AttributeKey<String> IOS_STATE = stringKey("ios.state");
 
   /**
    * This attribute represents the state the application has transitioned into at the occurrence of
@@ -249,7 +257,7 @@ public final class SemanticAttributes {
    *       lifecycle callbacks</a>, and from which the {@code OS identifiers} are derived.
    * </ul>
    */
-  public static final AttributeKey<String> ANDROID_STATE = stringKey("android.state");
+  @Deprecated public static final AttributeKey<String> ANDROID_STATE = stringKey("android.state");
 
   /**
    * The name of the connection pool; unique within the instrumented application. In case the
@@ -257,10 +265,10 @@ public final class SemanticAttributes {
    * href="/docs/database/database-spans.md#connection-level-attributes">db.connection_string</a>
    * should be used
    */
-  public static final AttributeKey<String> POOL_NAME = stringKey("pool.name");
+  @Deprecated public static final AttributeKey<String> POOL_NAME = stringKey("pool.name");
 
   /** The state of a connection in the pool */
-  public static final AttributeKey<String> STATE = stringKey("state");
+  @Deprecated public static final AttributeKey<String> STATE = stringKey("state");
 
   /**
    * Name of the buffer pool.
@@ -272,6 +280,7 @@ public final class SemanticAttributes {
    *       href="https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName()">BufferPoolMXBean#getName()</a>.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> JVM_BUFFER_POOL_NAME = stringKey("jvm.buffer.pool.name");
 
   /**
@@ -284,9 +293,11 @@ public final class SemanticAttributes {
    *       href="https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()">MemoryPoolMXBean#getName()</a>.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> JVM_MEMORY_POOL_NAME = stringKey("jvm.memory.pool.name");
 
   /** The type of memory. */
+  @Deprecated
   public static final AttributeKey<String> JVM_MEMORY_TYPE = stringKey("jvm.memory.type");
 
   /**
@@ -299,7 +310,7 @@ public final class SemanticAttributes {
    *       href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()">GarbageCollectionNotificationInfo#getGcAction()</a>.
    * </ul>
    */
-  public static final AttributeKey<String> JVM_GC_ACTION = stringKey("jvm.gc.action");
+  @Deprecated public static final AttributeKey<String> JVM_GC_ACTION = stringKey("jvm.gc.action");
 
   /**
    * Name of the garbage collector.
@@ -311,62 +322,77 @@ public final class SemanticAttributes {
    *       href="https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcName()">GarbageCollectionNotificationInfo#getGcName()</a>.
    * </ul>
    */
-  public static final AttributeKey<String> JVM_GC_NAME = stringKey("jvm.gc.name");
+  @Deprecated public static final AttributeKey<String> JVM_GC_NAME = stringKey("jvm.gc.name");
 
   /** Whether the thread is daemon or not. */
+  @Deprecated
   public static final AttributeKey<Boolean> JVM_THREAD_DAEMON = booleanKey("jvm.thread.daemon");
 
   /** State of the thread. */
+  @Deprecated
   public static final AttributeKey<String> JVM_THREAD_STATE = stringKey("jvm.thread.state");
 
   /** The device identifier */
-  public static final AttributeKey<String> SYSTEM_DEVICE = stringKey("system.device");
+  @Deprecated public static final AttributeKey<String> SYSTEM_DEVICE = stringKey("system.device");
 
   /** The logical CPU number [0..n-1] */
+  @Deprecated
   public static final AttributeKey<Long> SYSTEM_CPU_LOGICAL_NUMBER =
       longKey("system.cpu.logical_number");
 
   /** The state of the CPU */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_CPU_STATE = stringKey("system.cpu.state");
 
   /** The memory state */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_MEMORY_STATE = stringKey("system.memory.state");
 
   /** The paging access direction */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_PAGING_DIRECTION =
       stringKey("system.paging.direction");
 
   /** The memory paging state */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_PAGING_STATE = stringKey("system.paging.state");
 
   /** The memory paging type */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_PAGING_TYPE = stringKey("system.paging.type");
 
   /** The disk operation direction */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_DISK_DIRECTION =
       stringKey("system.disk.direction");
 
   /** The filesystem mode */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_FILESYSTEM_MODE =
       stringKey("system.filesystem.mode");
 
   /** The filesystem mount path */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_FILESYSTEM_MOUNTPOINT =
       stringKey("system.filesystem.mountpoint");
 
   /** The filesystem state */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_FILESYSTEM_STATE =
       stringKey("system.filesystem.state");
 
   /** The filesystem type */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_FILESYSTEM_TYPE =
       stringKey("system.filesystem.type");
 
   /** */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_NETWORK_DIRECTION =
       stringKey("system.network.direction");
 
   /** A stateless protocol MUST NOT set this attribute */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_NETWORK_STATE = stringKey("system.network.state");
 
   /**
@@ -374,6 +400,7 @@ public final class SemanticAttributes {
    * href="https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES">Linux Process State
    * Codes</a>
    */
+  @Deprecated
   public static final AttributeKey<String> SYSTEM_PROCESSES_STATUS =
       stringKey("system.processes.status");
 
@@ -381,31 +408,31 @@ public final class SemanticAttributes {
    * The column number in {@code code.filepath} best representing the operation. It SHOULD point
    * within the code unit named in {@code code.function}.
    */
-  public static final AttributeKey<Long> CODE_COLUMN = longKey("code.column");
+  @Deprecated public static final AttributeKey<Long> CODE_COLUMN = longKey("code.column");
 
   /**
    * The source code file name that identifies the code unit as uniquely as possible (preferably an
    * absolute file path).
    */
-  public static final AttributeKey<String> CODE_FILEPATH = stringKey("code.filepath");
+  @Deprecated public static final AttributeKey<String> CODE_FILEPATH = stringKey("code.filepath");
 
   /**
    * The method or function name, or equivalent (usually rightmost part of the code unit's name).
    */
-  public static final AttributeKey<String> CODE_FUNCTION = stringKey("code.function");
+  @Deprecated public static final AttributeKey<String> CODE_FUNCTION = stringKey("code.function");
 
   /**
    * The line number in {@code code.filepath} best representing the operation. It SHOULD point
    * within the code unit named in {@code code.function}.
    */
-  public static final AttributeKey<Long> CODE_LINENO = longKey("code.lineno");
+  @Deprecated public static final AttributeKey<Long> CODE_LINENO = longKey("code.lineno");
 
   /**
    * The &quot;namespace&quot; within which {@code code.function} is defined. Usually the qualified
    * class or module name, such that {@code code.namespace} + some separator + {@code code.function}
    * form a unique identifier for the code unit.
    */
-  public static final AttributeKey<String> CODE_NAMESPACE = stringKey("code.namespace");
+  @Deprecated public static final AttributeKey<String> CODE_NAMESPACE = stringKey("code.namespace");
 
   /**
    * Deprecated, use {@code http.request.method} instead.
@@ -567,6 +594,7 @@ public final class SemanticAttributes {
    * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
    * header. For requests using transport encoding, this should be the compressed size.
    */
+  @Deprecated
   public static final AttributeKey<Long> HTTP_REQUEST_BODY_SIZE = longKey("http.request.body.size");
 
   /**
@@ -594,9 +622,11 @@ public final class SemanticAttributes {
    *       to the original value.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> HTTP_REQUEST_METHOD = stringKey("http.request.method");
 
   /** Original HTTP method sent by the client in the request line. */
+  @Deprecated
   public static final AttributeKey<String> HTTP_REQUEST_METHOD_ORIGINAL =
       stringKey("http.request.method_original");
 
@@ -611,6 +641,7 @@ public final class SemanticAttributes {
    *       failure, 503 Server Unavailable, network issues, or any other).
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<Long> HTTP_REQUEST_RESEND_COUNT =
       longKey("http.request.resend_count");
 
@@ -620,10 +651,12 @@ public final class SemanticAttributes {
    * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
    * header. For requests using transport encoding, this should be the compressed size.
    */
+  @Deprecated
   public static final AttributeKey<Long> HTTP_RESPONSE_BODY_SIZE =
       longKey("http.response.body.size");
 
   /** <a href="https://tools.ietf.org/html/rfc7231#section-6">HTTP response status code</a>. */
+  @Deprecated
   public static final AttributeKey<Long> HTTP_RESPONSE_STATUS_CODE =
       longKey("http.response.status_code");
 
@@ -640,7 +673,7 @@ public final class SemanticAttributes {
    *       root</a> if there is one.
    * </ul>
    */
-  public static final AttributeKey<String> HTTP_ROUTE = stringKey("http.route");
+  @Deprecated public static final AttributeKey<String> HTTP_ROUTE = stringKey("http.route");
 
   /**
    * The number of messages sent, received, or processed in the scope of the batching operation.
@@ -655,16 +688,19 @@ public final class SemanticAttributes {
    *       APIs.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
       longKey("messaging.batch.message_count");
 
   /** A unique identifier for the client that consumes or produces a message. */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_CLIENT_ID = stringKey("messaging.client_id");
 
   /**
    * A boolean that is true if the message destination is anonymous (could be unnamed or have
    * auto-generated name).
    */
+  @Deprecated
   public static final AttributeKey<Boolean> MESSAGING_DESTINATION_ANONYMOUS =
       booleanKey("messaging.destination.anonymous");
 
@@ -679,6 +715,7 @@ public final class SemanticAttributes {
    *       identify the broker.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
       stringKey("messaging.destination.name");
 
@@ -694,6 +731,7 @@ public final class SemanticAttributes {
    *       used for grouping and aggregation.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_DESTINATION_TEMPLATE =
       stringKey("messaging.destination.template");
 
@@ -701,6 +739,7 @@ public final class SemanticAttributes {
    * A boolean that is true if the message destination is temporary and might not exist anymore
    * after messages are processed.
    */
+  @Deprecated
   public static final AttributeKey<Boolean> MESSAGING_DESTINATION_TEMPORARY =
       booleanKey("messaging.destination.temporary");
 
@@ -708,6 +747,7 @@ public final class SemanticAttributes {
    * A boolean that is true if the publish message destination is anonymous (could be unnamed or
    * have auto-generated name).
    */
+  @Deprecated
   public static final AttributeKey<Boolean> MESSAGING_DESTINATION_PUBLISH_ANONYMOUS =
       booleanKey("messaging.destination_publish.anonymous");
 
@@ -722,6 +762,7 @@ public final class SemanticAttributes {
    *       uniquely identify the broker.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_DESTINATION_PUBLISH_NAME =
       stringKey("messaging.destination_publish.name");
 
@@ -729,10 +770,12 @@ public final class SemanticAttributes {
    * Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not
    * producers.
    */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_KAFKA_CONSUMER_GROUP =
       stringKey("messaging.kafka.consumer.group");
 
   /** Partition the message is sent to. */
+  @Deprecated
   public static final AttributeKey<Long> MESSAGING_KAFKA_DESTINATION_PARTITION =
       longKey("messaging.kafka.destination.partition");
 
@@ -748,14 +791,17 @@ public final class SemanticAttributes {
    *       attribute. If the key has no unambiguous, canonical string form, don't include its value.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_KAFKA_MESSAGE_KEY =
       stringKey("messaging.kafka.message.key");
 
   /** The offset of a record in the corresponding Kafka partition. */
+  @Deprecated
   public static final AttributeKey<Long> MESSAGING_KAFKA_MESSAGE_OFFSET =
       longKey("messaging.kafka.message.offset");
 
   /** A boolean that is true if the message is a tombstone. */
+  @Deprecated
   public static final AttributeKey<Boolean> MESSAGING_KAFKA_MESSAGE_TOMBSTONE =
       booleanKey("messaging.kafka.message.tombstone");
 
@@ -769,6 +815,7 @@ public final class SemanticAttributes {
    *       the uncompressed body size should be used.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<Long> MESSAGING_MESSAGE_BODY_SIZE =
       longKey("messaging.message.body.size");
 
@@ -776,6 +823,7 @@ public final class SemanticAttributes {
    * The conversation ID identifying the conversation to which the message belongs, represented as a
    * string. Sometimes called &quot;Correlation ID&quot;.
    */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_MESSAGE_CONVERSATION_ID =
       stringKey("messaging.message.conversation_id");
 
@@ -789,12 +837,14 @@ public final class SemanticAttributes {
    *       uncompressed size should be used.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<Long> MESSAGING_MESSAGE_ENVELOPE_SIZE =
       longKey("messaging.message.envelope.size");
 
   /**
    * A value used by the messaging system as an identifier for the message, represented as a string.
    */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_MESSAGE_ID = stringKey("messaging.message.id");
 
   /**
@@ -806,9 +856,11 @@ public final class SemanticAttributes {
    *   <li>If a custom value is used, it MUST be of low cardinality.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_OPERATION = stringKey("messaging.operation");
 
   /** RabbitMQ message routing key. */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY =
       stringKey("messaging.rabbitmq.destination.routing_key");
 
@@ -816,20 +868,24 @@ public final class SemanticAttributes {
    * Name of the RocketMQ producer/consumer group that is handling the message. The client type is
    * identified by the SpanKind.
    */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_ROCKETMQ_CLIENT_GROUP =
       stringKey("messaging.rocketmq.client_group");
 
   /** Model of message consumption. This only applies to consumer spans. */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_ROCKETMQ_CONSUMPTION_MODEL =
       stringKey("messaging.rocketmq.consumption_model");
 
   /** The delay time level for delay message, which determines the message delay time. */
+  @Deprecated
   public static final AttributeKey<Long> MESSAGING_ROCKETMQ_MESSAGE_DELAY_TIME_LEVEL =
       longKey("messaging.rocketmq.message.delay_time_level");
 
   /**
    * The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
    */
+  @Deprecated
   public static final AttributeKey<Long> MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP =
       longKey("messaging.rocketmq.message.delivery_timestamp");
 
@@ -837,62 +893,78 @@ public final class SemanticAttributes {
    * It is essential for FIFO message. Messages that belong to the same message group are always
    * processed one by one within the same consumer group.
    */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_ROCKETMQ_MESSAGE_GROUP =
       stringKey("messaging.rocketmq.message.group");
 
   /** Key(s) of message, another way to mark message besides message id. */
+  @Deprecated
   public static final AttributeKey<List<String>> MESSAGING_ROCKETMQ_MESSAGE_KEYS =
       stringArrayKey("messaging.rocketmq.message.keys");
 
   /** The secondary classifier of message besides topic. */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_ROCKETMQ_MESSAGE_TAG =
       stringKey("messaging.rocketmq.message.tag");
 
   /** Type of message. */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_ROCKETMQ_MESSAGE_TYPE =
       stringKey("messaging.rocketmq.message.type");
 
   /** Namespace of RocketMQ resources, resources in different namespaces are individual. */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_ROCKETMQ_NAMESPACE =
       stringKey("messaging.rocketmq.namespace");
 
   /** A string identifying the messaging system. */
+  @Deprecated
   public static final AttributeKey<String> MESSAGING_SYSTEM = stringKey("messaging.system");
 
   /** The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network. */
+  @Deprecated
   public static final AttributeKey<String> NETWORK_CARRIER_ICC = stringKey("network.carrier.icc");
 
   /** The mobile carrier country code. */
+  @Deprecated
   public static final AttributeKey<String> NETWORK_CARRIER_MCC = stringKey("network.carrier.mcc");
 
   /** The mobile carrier network code. */
+  @Deprecated
   public static final AttributeKey<String> NETWORK_CARRIER_MNC = stringKey("network.carrier.mnc");
 
   /** The name of the mobile carrier. */
+  @Deprecated
   public static final AttributeKey<String> NETWORK_CARRIER_NAME = stringKey("network.carrier.name");
 
   /**
    * This describes more details regarding the connection.type. It may be the type of cell
    * technology connection, but it could be used for describing details about a wifi connection.
    */
+  @Deprecated
   public static final AttributeKey<String> NETWORK_CONNECTION_SUBTYPE =
       stringKey("network.connection.subtype");
 
   /** The internet connection type. */
+  @Deprecated
   public static final AttributeKey<String> NETWORK_CONNECTION_TYPE =
       stringKey("network.connection.type");
 
   /** Local address of the network connection - IP address or Unix domain socket name. */
+  @Deprecated
   public static final AttributeKey<String> NETWORK_LOCAL_ADDRESS =
       stringKey("network.local.address");
 
   /** Local port number of the network connection. */
+  @Deprecated
   public static final AttributeKey<Long> NETWORK_LOCAL_PORT = longKey("network.local.port");
 
   /** Peer address of the network connection - IP address or Unix domain socket name. */
+  @Deprecated
   public static final AttributeKey<String> NETWORK_PEER_ADDRESS = stringKey("network.peer.address");
 
   /** Peer port number of the network connection. */
+  @Deprecated
   public static final AttributeKey<Long> NETWORK_PEER_PORT = longKey("network.peer.port");
 
   /**
@@ -905,6 +977,7 @@ public final class SemanticAttributes {
    *   <li>The value SHOULD be normalized to lowercase.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> NETWORK_PROTOCOL_NAME =
       stringKey("network.protocol.name");
 
@@ -919,6 +992,7 @@ public final class SemanticAttributes {
    *       0.27.2}, but sends HTTP version {@code 1.1}, this attribute should be set to {@code 1.1}.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> NETWORK_PROTOCOL_VERSION =
       stringKey("network.protocol.version");
 
@@ -936,6 +1010,7 @@ public final class SemanticAttributes {
    *       listening on TCP port 12345 and UDP port 12345.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> NETWORK_TRANSPORT = stringKey("network.transport");
 
   /**
@@ -947,12 +1022,13 @@ public final class SemanticAttributes {
    *   <li>The value SHOULD be normalized to lowercase.
    * </ul>
    */
-  public static final AttributeKey<String> NETWORK_TYPE = stringKey("network.type");
+  @Deprecated public static final AttributeKey<String> NETWORK_TYPE = stringKey("network.type");
 
   /**
    * The <a href="https://connect.build/docs/protocol/#error-codes">error codes</a> of the Connect
    * request. Error codes are always string values.
    */
+  @Deprecated
   public static final AttributeKey<String> RPC_CONNECT_RPC_ERROR_CODE =
       stringKey("rpc.connect_rpc.error_code");
 
@@ -960,12 +1036,15 @@ public final class SemanticAttributes {
    * The <a href="https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md">numeric status
    * code</a> of the gRPC request.
    */
+  @Deprecated
   public static final AttributeKey<Long> RPC_GRPC_STATUS_CODE = longKey("rpc.grpc.status_code");
 
   /** {@code error.code} property of response if it is an error response. */
+  @Deprecated
   public static final AttributeKey<Long> RPC_JSONRPC_ERROR_CODE = longKey("rpc.jsonrpc.error_code");
 
   /** {@code error.message} property of response if it is an error response. */
+  @Deprecated
   public static final AttributeKey<String> RPC_JSONRPC_ERROR_MESSAGE =
       stringKey("rpc.jsonrpc.error_message");
 
@@ -974,6 +1053,7 @@ public final class SemanticAttributes {
    * null} or missing (for notifications), value is expected to be cast to string for simplicity.
    * Use empty string in case of {@code null} value. Omit entirely if this is a notification.
    */
+  @Deprecated
   public static final AttributeKey<String> RPC_JSONRPC_REQUEST_ID =
       stringKey("rpc.jsonrpc.request_id");
 
@@ -981,6 +1061,7 @@ public final class SemanticAttributes {
    * Protocol version as in {@code jsonrpc} property of request/response. Since JSON-RPC 1.0 doesn't
    * specify this, the value can be omitted.
    */
+  @Deprecated
   public static final AttributeKey<String> RPC_JSONRPC_VERSION = stringKey("rpc.jsonrpc.version");
 
   /**
@@ -996,7 +1077,7 @@ public final class SemanticAttributes {
    *       the server side, RPC client stub method on the client side).
    * </ul>
    */
-  public static final AttributeKey<String> RPC_METHOD = stringKey("rpc.method");
+  @Deprecated public static final AttributeKey<String> RPC_METHOD = stringKey("rpc.method");
 
   /**
    * The full (logical) name of the service being called, including its package name, if applicable.
@@ -1011,19 +1092,19 @@ public final class SemanticAttributes {
    *       class on the client side).
    * </ul>
    */
-  public static final AttributeKey<String> RPC_SERVICE = stringKey("rpc.service");
+  @Deprecated public static final AttributeKey<String> RPC_SERVICE = stringKey("rpc.service");
 
   /** A string identifying the remoting system. See below for a list of well-known identifiers. */
-  public static final AttributeKey<String> RPC_SYSTEM = stringKey("rpc.system");
+  @Deprecated public static final AttributeKey<String> RPC_SYSTEM = stringKey("rpc.system");
 
   /** Current &quot;managed&quot; thread ID (as opposed to OS thread ID). */
-  public static final AttributeKey<Long> THREAD_ID = longKey("thread.id");
+  @Deprecated public static final AttributeKey<Long> THREAD_ID = longKey("thread.id");
 
   /** Current thread name. */
-  public static final AttributeKey<String> THREAD_NAME = stringKey("thread.name");
+  @Deprecated public static final AttributeKey<String> THREAD_NAME = stringKey("thread.name");
 
   /** The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.5">URI fragment</a> component */
-  public static final AttributeKey<String> URL_FRAGMENT = stringKey("url.fragment");
+  @Deprecated public static final AttributeKey<String> URL_FRAGMENT = stringKey("url.fragment");
 
   /**
    * Absolute URL describing a network resource according to <a
@@ -1042,10 +1123,10 @@ public final class SemanticAttributes {
    *       modified except for sanitizing purposes.
    * </ul>
    */
-  public static final AttributeKey<String> URL_FULL = stringKey("url.full");
+  @Deprecated public static final AttributeKey<String> URL_FULL = stringKey("url.full");
 
   /** The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.3">URI path</a> component */
-  public static final AttributeKey<String> URL_PATH = stringKey("url.path");
+  @Deprecated public static final AttributeKey<String> URL_PATH = stringKey("url.path");
 
   /**
    * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.4">URI query</a> component
@@ -1057,18 +1138,19 @@ public final class SemanticAttributes {
    *       identify it.
    * </ul>
    */
-  public static final AttributeKey<String> URL_QUERY = stringKey("url.query");
+  @Deprecated public static final AttributeKey<String> URL_QUERY = stringKey("url.query");
 
   /**
    * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.1">URI scheme</a> component
    * identifying the used protocol.
    */
-  public static final AttributeKey<String> URL_SCHEME = stringKey("url.scheme");
+  @Deprecated public static final AttributeKey<String> URL_SCHEME = stringKey("url.scheme");
 
   /**
    * Value of the <a href="https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent">HTTP
    * User-Agent</a> header sent by the client.
    */
+  @Deprecated
   public static final AttributeKey<String> USER_AGENT_ORIGINAL = stringKey("user_agent.original");
 
   /**
@@ -1083,7 +1165,7 @@ public final class SemanticAttributes {
    *       example proxies, if it's available.
    * </ul>
    */
-  public static final AttributeKey<String> SERVER_ADDRESS = stringKey("server.address");
+  @Deprecated public static final AttributeKey<String> SERVER_ADDRESS = stringKey("server.address");
 
   /**
    * Server port number.
@@ -1096,12 +1178,13 @@ public final class SemanticAttributes {
    *       example proxies, if it's available.
    * </ul>
    */
-  public static final AttributeKey<Long> SERVER_PORT = longKey("server.port");
+  @Deprecated public static final AttributeKey<Long> SERVER_PORT = longKey("server.port");
 
   /** A unique id to identify a session. */
-  public static final AttributeKey<String> SESSION_ID = stringKey("session.id");
+  @Deprecated public static final AttributeKey<String> SESSION_ID = stringKey("session.id");
 
   /** The previous {@code session.id} for this user, when known. */
+  @Deprecated
   public static final AttributeKey<String> SESSION_PREVIOUS_ID = stringKey("session.previous_id");
 
   /**
@@ -1116,10 +1199,10 @@ public final class SemanticAttributes {
    *       example proxies, if it's available.
    * </ul>
    */
-  public static final AttributeKey<String> SOURCE_ADDRESS = stringKey("source.address");
+  @Deprecated public static final AttributeKey<String> SOURCE_ADDRESS = stringKey("source.address");
 
   /** Source port number */
-  public static final AttributeKey<Long> SOURCE_PORT = longKey("source.port");
+  @Deprecated public static final AttributeKey<Long> SOURCE_PORT = longKey("source.port");
 
   /**
    * The full invoked ARN as provided on the {@code Context} passed to the function ({@code
@@ -1132,6 +1215,7 @@ public final class SemanticAttributes {
    *   <li>This may be different from {@code cloud.resource_id} if an alias is involved.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> AWS_LAMBDA_INVOKED_ARN =
       stringKey("aws.lambda.invoked_arn");
 
@@ -1140,6 +1224,7 @@ public final class SemanticAttributes {
    * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id">event_id</a>
    * uniquely identifies the event.
    */
+  @Deprecated
   public static final AttributeKey<String> CLOUDEVENTS_EVENT_ID = stringKey("cloudevents.event_id");
 
   /**
@@ -1147,6 +1232,7 @@ public final class SemanticAttributes {
    * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#source-1">source</a>
    * identifies the context in which an event happened.
    */
+  @Deprecated
   public static final AttributeKey<String> CLOUDEVENTS_EVENT_SOURCE =
       stringKey("cloudevents.event_source");
 
@@ -1155,6 +1241,7 @@ public final class SemanticAttributes {
    * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#specversion">version
    * of the CloudEvents specification</a> which the event uses.
    */
+  @Deprecated
   public static final AttributeKey<String> CLOUDEVENTS_EVENT_SPEC_VERSION =
       stringKey("cloudevents.event_spec_version");
 
@@ -1163,6 +1250,7 @@ public final class SemanticAttributes {
    * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#subject">subject</a>
    * of the event in the context of the event producer (identified by source).
    */
+  @Deprecated
   public static final AttributeKey<String> CLOUDEVENTS_EVENT_SUBJECT =
       stringKey("cloudevents.event_subject");
 
@@ -1171,6 +1259,7 @@ public final class SemanticAttributes {
    * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type">event_type</a>
    * contains a value describing the type of event related to the originating occurrence.
    */
+  @Deprecated
   public static final AttributeKey<String> CLOUDEVENTS_EVENT_TYPE =
       stringKey("cloudevents.event_type");
 
@@ -1183,12 +1272,14 @@ public final class SemanticAttributes {
    *   <li>The causal relationship between a child Span and a parent Span.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> OPENTRACING_REF_TYPE = stringKey("opentracing.ref_type");
 
   /**
    * The connection string used to connect to the database. It is recommended to remove embedded
    * credentials.
    */
+  @Deprecated
   public static final AttributeKey<String> DB_CONNECTION_STRING = stringKey("db.connection_string");
 
   /**
@@ -1196,6 +1287,7 @@ public final class SemanticAttributes {
    * href="https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/">Java Database Connectivity
    * (JDBC)</a> driver used to connect.
    */
+  @Deprecated
   public static final AttributeKey<String> DB_JDBC_DRIVER_CLASSNAME =
       stringKey("db.jdbc.driver_classname");
 
@@ -1212,7 +1304,7 @@ public final class SemanticAttributes {
    *       (e.g. Oracle schema name).
    * </ul>
    */
-  public static final AttributeKey<String> DB_NAME = stringKey("db.name");
+  @Deprecated public static final AttributeKey<String> DB_NAME = stringKey("db.name");
 
   /**
    * The name of the operation being executed, e.g. the <a
@@ -1228,19 +1320,19 @@ public final class SemanticAttributes {
    *       ambiguous operation, or performs more than one operation, this value may be omitted.
    * </ul>
    */
-  public static final AttributeKey<String> DB_OPERATION = stringKey("db.operation");
+  @Deprecated public static final AttributeKey<String> DB_OPERATION = stringKey("db.operation");
 
   /** The database statement being executed. */
-  public static final AttributeKey<String> DB_STATEMENT = stringKey("db.statement");
+  @Deprecated public static final AttributeKey<String> DB_STATEMENT = stringKey("db.statement");
 
   /**
    * An identifier for the database management system (DBMS) product being used. See below for a
    * list of well-known identifiers.
    */
-  public static final AttributeKey<String> DB_SYSTEM = stringKey("db.system");
+  @Deprecated public static final AttributeKey<String> DB_SYSTEM = stringKey("db.system");
 
   /** Username for accessing the database. */
-  public static final AttributeKey<String> DB_USER = stringKey("db.user");
+  @Deprecated public static final AttributeKey<String> DB_USER = stringKey("db.user");
 
   /**
    * The Microsoft SQL Server <a
@@ -1254,6 +1346,7 @@ public final class SemanticAttributes {
    *       (but still recommended if non-standard).
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> DB_MSSQL_INSTANCE_NAME =
       stringKey("db.mssql.instance_name");
 
@@ -1261,28 +1354,34 @@ public final class SemanticAttributes {
    * The consistency level of the query. Based on consistency values from <a
    * href="https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html">CQL</a>.
    */
+  @Deprecated
   public static final AttributeKey<String> DB_CASSANDRA_CONSISTENCY_LEVEL =
       stringKey("db.cassandra.consistency_level");
 
   /** The data center of the coordinating node for a query. */
+  @Deprecated
   public static final AttributeKey<String> DB_CASSANDRA_COORDINATOR_DC =
       stringKey("db.cassandra.coordinator.dc");
 
   /** The ID of the coordinating node for a query. */
+  @Deprecated
   public static final AttributeKey<String> DB_CASSANDRA_COORDINATOR_ID =
       stringKey("db.cassandra.coordinator.id");
 
   /** Whether or not the query is idempotent. */
+  @Deprecated
   public static final AttributeKey<Boolean> DB_CASSANDRA_IDEMPOTENCE =
       booleanKey("db.cassandra.idempotence");
 
   /** The fetch size used for paging, i.e. how many rows will be returned at once. */
+  @Deprecated
   public static final AttributeKey<Long> DB_CASSANDRA_PAGE_SIZE = longKey("db.cassandra.page_size");
 
   /**
    * The number of times a query was speculatively executed. Not set or {@code 0} if the query was
    * not executed speculatively.
    */
+  @Deprecated
   public static final AttributeKey<Long> DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT =
       longKey("db.cassandra.speculative_execution_count");
 
@@ -1300,6 +1399,7 @@ public final class SemanticAttributes {
    *       MUST NOT be set.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> DB_CASSANDRA_TABLE = stringKey("db.cassandra.table");
 
   /**
@@ -1307,20 +1407,24 @@ public final class SemanticAttributes {
    * href="https://redis.io/commands/select">{@code SELECT} command</a>, provided as an integer. To
    * be used instead of the generic {@code db.name} attribute.
    */
+  @Deprecated
   public static final AttributeKey<Long> DB_REDIS_DATABASE_INDEX =
       longKey("db.redis.database_index");
 
   /** The collection being accessed within the database stated in {@code db.name}. */
+  @Deprecated
   public static final AttributeKey<String> DB_MONGODB_COLLECTION =
       stringKey("db.mongodb.collection");
 
   /** Represents the identifier of an Elasticsearch cluster. */
+  @Deprecated
   public static final AttributeKey<String> DB_ELASTICSEARCH_CLUSTER_NAME =
       stringKey("db.elasticsearch.cluster.name");
 
   /**
    * Represents the human-readable identifier of the node/instance to which a request was routed.
    */
+  @Deprecated
   public static final AttributeKey<String> DB_ELASTICSEARCH_NODE_NAME =
       stringKey("db.elasticsearch.node.name");
 
@@ -1337,37 +1441,45 @@ public final class SemanticAttributes {
    *       this value MUST NOT be set.
    * </ul>
    */
-  public static final AttributeKey<String> DB_SQL_TABLE = stringKey("db.sql.table");
+  @Deprecated public static final AttributeKey<String> DB_SQL_TABLE = stringKey("db.sql.table");
 
   /** Unique Cosmos client instance id. */
+  @Deprecated
   public static final AttributeKey<String> DB_COSMOSDB_CLIENT_ID =
       stringKey("db.cosmosdb.client_id");
 
   /** Cosmos client connection mode. */
+  @Deprecated
   public static final AttributeKey<String> DB_COSMOSDB_CONNECTION_MODE =
       stringKey("db.cosmosdb.connection_mode");
 
   /** Cosmos DB container name. */
+  @Deprecated
   public static final AttributeKey<String> DB_COSMOSDB_CONTAINER =
       stringKey("db.cosmosdb.container");
 
   /** CosmosDB Operation Type. */
+  @Deprecated
   public static final AttributeKey<String> DB_COSMOSDB_OPERATION_TYPE =
       stringKey("db.cosmosdb.operation_type");
 
   /** RU consumed for that operation */
+  @Deprecated
   public static final AttributeKey<Double> DB_COSMOSDB_REQUEST_CHARGE =
       doubleKey("db.cosmosdb.request_charge");
 
   /** Request payload size in bytes */
+  @Deprecated
   public static final AttributeKey<Long> DB_COSMOSDB_REQUEST_CONTENT_LENGTH =
       longKey("db.cosmosdb.request_content_length");
 
   /** Cosmos DB status code. */
+  @Deprecated
   public static final AttributeKey<Long> DB_COSMOSDB_STATUS_CODE =
       longKey("db.cosmosdb.status_code");
 
   /** Cosmos DB sub status code. */
+  @Deprecated
   public static final AttributeKey<Long> DB_COSMOSDB_SUB_STATUS_CODE =
       longKey("db.cosmosdb.sub_status_code");
 
@@ -1375,19 +1487,23 @@ public final class SemanticAttributes {
    * Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set if the status
    * code is UNSET.
    */
+  @Deprecated
   public static final AttributeKey<String> OTEL_STATUS_CODE = stringKey("otel.status_code");
 
   /** Description of the Status if it has a value, otherwise not set. */
+  @Deprecated
   public static final AttributeKey<String> OTEL_STATUS_DESCRIPTION =
       stringKey("otel.status_description");
 
   /** The invocation ID of the current function invocation. */
+  @Deprecated
   public static final AttributeKey<String> FAAS_INVOCATION_ID = stringKey("faas.invocation_id");
 
   /**
    * The name of the source on which the triggering operation was performed. For example, in Cloud
    * Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name.
    */
+  @Deprecated
   public static final AttributeKey<String> FAAS_DOCUMENT_COLLECTION =
       stringKey("faas.document.collection");
 
@@ -1395,9 +1511,11 @@ public final class SemanticAttributes {
    * The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the
    * name of the file, and in Cosmos DB the table name.
    */
+  @Deprecated
   public static final AttributeKey<String> FAAS_DOCUMENT_NAME = stringKey("faas.document.name");
 
   /** Describes the type of the operation that was performed on the data. */
+  @Deprecated
   public static final AttributeKey<String> FAAS_DOCUMENT_OPERATION =
       stringKey("faas.document.operation");
 
@@ -1406,6 +1524,7 @@ public final class SemanticAttributes {
    * href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO 8601</a> format expressed in
    * <a href="https://www.w3.org/TR/NOTE-datetime">UTC</a>.
    */
+  @Deprecated
   public static final AttributeKey<String> FAAS_DOCUMENT_TIME = stringKey("faas.document.time");
 
   /**
@@ -1413,25 +1532,28 @@ public final class SemanticAttributes {
    * href="https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm">Cron
    * Expression</a>.
    */
-  public static final AttributeKey<String> FAAS_CRON = stringKey("faas.cron");
+  @Deprecated public static final AttributeKey<String> FAAS_CRON = stringKey("faas.cron");
 
   /**
    * A string containing the function invocation time in the <a
    * href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO 8601</a> format expressed in
    * <a href="https://www.w3.org/TR/NOTE-datetime">UTC</a>.
    */
-  public static final AttributeKey<String> FAAS_TIME = stringKey("faas.time");
+  @Deprecated public static final AttributeKey<String> FAAS_TIME = stringKey("faas.time");
 
   /**
    * A boolean that is true if the serverless function is executed for the first time (aka
    * cold-start).
    */
+  @Deprecated
   public static final AttributeKey<Boolean> FAAS_COLDSTART = booleanKey("faas.coldstart");
 
   /** The unique identifier of the feature flag. */
+  @Deprecated
   public static final AttributeKey<String> FEATURE_FLAG_KEY = stringKey("feature_flag.key");
 
   /** The name of the service provider that performs the flag evaluation. */
+  @Deprecated
   public static final AttributeKey<String> FEATURE_FLAG_PROVIDER_NAME =
       stringKey("feature_flag.provider_name");
 
@@ -1451,91 +1573,113 @@ public final class SemanticAttributes {
    *       implementer.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> FEATURE_FLAG_VARIANT = stringKey("feature_flag.variant");
 
   /**
    * The AWS request ID as returned in the response headers {@code x-amz-request-id} or {@code
    * x-amz-requestid}.
    */
-  public static final AttributeKey<String> AWS_REQUEST_ID = stringKey("aws.request_id");
+  @Deprecated public static final AttributeKey<String> AWS_REQUEST_ID = stringKey("aws.request_id");
 
   /** The value of the {@code AttributesToGet} request parameter. */
+  @Deprecated
   public static final AttributeKey<List<String>> AWS_DYNAMODB_ATTRIBUTES_TO_GET =
       stringArrayKey("aws.dynamodb.attributes_to_get");
 
   /** The value of the {@code ConsistentRead} request parameter. */
+  @Deprecated
   public static final AttributeKey<Boolean> AWS_DYNAMODB_CONSISTENT_READ =
       booleanKey("aws.dynamodb.consistent_read");
 
   /** The JSON-serialized value of each item in the {@code ConsumedCapacity} response field. */
+  @Deprecated
   public static final AttributeKey<List<String>> AWS_DYNAMODB_CONSUMED_CAPACITY =
       stringArrayKey("aws.dynamodb.consumed_capacity");
 
   /** The value of the {@code IndexName} request parameter. */
+  @Deprecated
   public static final AttributeKey<String> AWS_DYNAMODB_INDEX_NAME =
       stringKey("aws.dynamodb.index_name");
 
   /** The JSON-serialized value of the {@code ItemCollectionMetrics} response field. */
+  @Deprecated
   public static final AttributeKey<String> AWS_DYNAMODB_ITEM_COLLECTION_METRICS =
       stringKey("aws.dynamodb.item_collection_metrics");
 
   /** The value of the {@code Limit} request parameter. */
+  @Deprecated
   public static final AttributeKey<Long> AWS_DYNAMODB_LIMIT = longKey("aws.dynamodb.limit");
 
   /** The value of the {@code ProjectionExpression} request parameter. */
+  @Deprecated
   public static final AttributeKey<String> AWS_DYNAMODB_PROJECTION =
       stringKey("aws.dynamodb.projection");
 
   /** The value of the {@code ProvisionedThroughput.ReadCapacityUnits} request parameter. */
+  @Deprecated
   public static final AttributeKey<Double> AWS_DYNAMODB_PROVISIONED_READ_CAPACITY =
       doubleKey("aws.dynamodb.provisioned_read_capacity");
 
   /** The value of the {@code ProvisionedThroughput.WriteCapacityUnits} request parameter. */
+  @Deprecated
   public static final AttributeKey<Double> AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY =
       doubleKey("aws.dynamodb.provisioned_write_capacity");
 
   /** The value of the {@code Select} request parameter. */
+  @Deprecated
   public static final AttributeKey<String> AWS_DYNAMODB_SELECT = stringKey("aws.dynamodb.select");
 
   /** The keys in the {@code RequestItems} object field. */
+  @Deprecated
   public static final AttributeKey<List<String>> AWS_DYNAMODB_TABLE_NAMES =
       stringArrayKey("aws.dynamodb.table_names");
 
   /** The JSON-serialized value of each item of the {@code GlobalSecondaryIndexes} request field */
+  @Deprecated
   public static final AttributeKey<List<String>> AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES =
       stringArrayKey("aws.dynamodb.global_secondary_indexes");
 
   /** The JSON-serialized value of each item of the {@code LocalSecondaryIndexes} request field. */
+  @Deprecated
   public static final AttributeKey<List<String>> AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES =
       stringArrayKey("aws.dynamodb.local_secondary_indexes");
 
   /** The value of the {@code ExclusiveStartTableName} request parameter. */
+  @Deprecated
   public static final AttributeKey<String> AWS_DYNAMODB_EXCLUSIVE_START_TABLE =
       stringKey("aws.dynamodb.exclusive_start_table");
 
   /** The the number of items in the {@code TableNames} response parameter. */
+  @Deprecated
   public static final AttributeKey<Long> AWS_DYNAMODB_TABLE_COUNT =
       longKey("aws.dynamodb.table_count");
 
   /** The value of the {@code ScanIndexForward} request parameter. */
+  @Deprecated
   public static final AttributeKey<Boolean> AWS_DYNAMODB_SCAN_FORWARD =
       booleanKey("aws.dynamodb.scan_forward");
 
   /** The value of the {@code Count} response parameter. */
+  @Deprecated
   public static final AttributeKey<Long> AWS_DYNAMODB_COUNT = longKey("aws.dynamodb.count");
 
   /** The value of the {@code ScannedCount} response parameter. */
+  @Deprecated
   public static final AttributeKey<Long> AWS_DYNAMODB_SCANNED_COUNT =
       longKey("aws.dynamodb.scanned_count");
 
   /** The value of the {@code Segment} request parameter. */
+  @Deprecated
   public static final AttributeKey<Long> AWS_DYNAMODB_SEGMENT = longKey("aws.dynamodb.segment");
 
   /** The value of the {@code TotalSegments} request parameter. */
+  @Deprecated
   public static final AttributeKey<Long> AWS_DYNAMODB_TOTAL_SEGMENTS =
       longKey("aws.dynamodb.total_segments");
 
   /** The JSON-serialized value of each item in the {@code AttributeDefinitions} request field. */
+  @Deprecated
   public static final AttributeKey<List<String>> AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS =
       stringArrayKey("aws.dynamodb.attribute_definitions");
 
@@ -1543,6 +1687,7 @@ public final class SemanticAttributes {
    * The JSON-serialized value of each item in the the {@code GlobalSecondaryIndexUpdates} request
    * field.
    */
+  @Deprecated
   public static final AttributeKey<List<String>> AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES =
       stringArrayKey("aws.dynamodb.global_secondary_index_updates");
 
@@ -1559,7 +1704,7 @@ public final class SemanticAttributes {
    *       operations except {@code list-buckets}.
    * </ul>
    */
-  public static final AttributeKey<String> AWS_S3_BUCKET = stringKey("aws.s3.bucket");
+  @Deprecated public static final AttributeKey<String> AWS_S3_BUCKET = stringKey("aws.s3.bucket");
 
   /**
    * The source object (in the form {@code bucket}/{@code key}) for the copy operation.
@@ -1577,6 +1722,7 @@ public final class SemanticAttributes {
    *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a>
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> AWS_S3_COPY_SOURCE = stringKey("aws.s3.copy_source");
 
   /**
@@ -1593,7 +1739,7 @@ public final class SemanticAttributes {
    *       operation within the S3 API</a>.
    * </ul>
    */
-  public static final AttributeKey<String> AWS_S3_DELETE = stringKey("aws.s3.delete");
+  @Deprecated public static final AttributeKey<String> AWS_S3_DELETE = stringKey("aws.s3.delete");
 
   /**
    * The S3 object key the request refers to. Corresponds to the {@code --key} parameter of the <a
@@ -1633,7 +1779,7 @@ public final class SemanticAttributes {
    *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a>
    * </ul>
    */
-  public static final AttributeKey<String> AWS_S3_KEY = stringKey("aws.s3.key");
+  @Deprecated public static final AttributeKey<String> AWS_S3_KEY = stringKey("aws.s3.key");
 
   /**
    * The part number of the part being uploaded in a multipart-upload operation. This is a positive
@@ -1652,6 +1798,7 @@ public final class SemanticAttributes {
    *       operation within the S3 API</a>.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<Long> AWS_S3_PART_NUMBER = longKey("aws.s3.part_number");
 
   /**
@@ -1676,6 +1823,7 @@ public final class SemanticAttributes {
    *       href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a>
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> AWS_S3_UPLOAD_ID = stringKey("aws.s3.upload_id");
 
   /**
@@ -1687,17 +1835,21 @@ public final class SemanticAttributes {
    *   <li>The value may be sanitized to exclude sensitive information.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<String> GRAPHQL_DOCUMENT = stringKey("graphql.document");
 
   /** The name of the operation being executed. */
+  @Deprecated
   public static final AttributeKey<String> GRAPHQL_OPERATION_NAME =
       stringKey("graphql.operation.name");
 
   /** The type of the operation being executed. */
+  @Deprecated
   public static final AttributeKey<String> GRAPHQL_OPERATION_TYPE =
       stringKey("graphql.operation.type");
 
   /** Compressed size of the message in bytes. */
+  @Deprecated
   public static final AttributeKey<Long> MESSAGE_COMPRESSED_SIZE =
       longKey("message.compressed_size");
 
@@ -1712,12 +1864,13 @@ public final class SemanticAttributes {
    *       implementations.
    * </ul>
    */
-  public static final AttributeKey<Long> MESSAGE_ID = longKey("message.id");
+  @Deprecated public static final AttributeKey<Long> MESSAGE_ID = longKey("message.id");
 
   /** Whether this is a received or sent message. */
-  public static final AttributeKey<String> MESSAGE_TYPE = stringKey("message.type");
+  @Deprecated public static final AttributeKey<String> MESSAGE_TYPE = stringKey("message.type");
 
   /** Uncompressed size of the message in bytes. */
+  @Deprecated
   public static final AttributeKey<Long> MESSAGE_UNCOMPRESSED_SIZE =
       longKey("message.uncompressed_size");
 
@@ -1742,6 +1895,7 @@ public final class SemanticAttributes {
    *       recorded at a time where it was not clear whether the exception will escape.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKey<Boolean> EXCEPTION_ESCAPED = booleanKey("exception.escaped");
 
   /**
@@ -1761,6 +1915,7 @@ public final class SemanticAttributes {
    *       library provides access to headers.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKeyTemplate<List<String>> HTTP_REQUEST_HEADER =
       stringArrayKeyTemplate("http.request.header");
 
@@ -1780,6 +1935,7 @@ public final class SemanticAttributes {
    *       library provides access to headers.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKeyTemplate<List<String>> HTTP_RESPONSE_HEADER =
       stringArrayKeyTemplate("http.response.header");
 
@@ -1795,6 +1951,7 @@ public final class SemanticAttributes {
    *       configuration helps avoid leaking sensitive information.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKeyTemplate<List<String>> RPC_CONNECT_RPC_REQUEST_METADATA =
       stringArrayKeyTemplate("rpc.connect_rpc.request.metadata");
 
@@ -1810,6 +1967,7 @@ public final class SemanticAttributes {
    *       configuration helps avoid leaking sensitive information.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKeyTemplate<List<String>> RPC_CONNECT_RPC_RESPONSE_METADATA =
       stringArrayKeyTemplate("rpc.connect_rpc.response.metadata");
 
@@ -1825,6 +1983,7 @@ public final class SemanticAttributes {
    *       configuration helps avoid leaking sensitive information.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKeyTemplate<List<String>> RPC_GRPC_REQUEST_METADATA =
       stringArrayKeyTemplate("rpc.grpc.request.metadata");
 
@@ -1840,6 +1999,7 @@ public final class SemanticAttributes {
    *       configuration helps avoid leaking sensitive information.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKeyTemplate<List<String>> RPC_GRPC_RESPONSE_METADATA =
       stringArrayKeyTemplate("rpc.grpc.response.metadata");
 
@@ -1856,221 +2016,234 @@ public final class SemanticAttributes {
    *       schema</a> in order to map the path part values to their names.
    * </ul>
    */
+  @Deprecated
   public static final AttributeKeyTemplate<String> DB_ELASTICSEARCH_PATH_PARTS =
       stringKeyTemplate("db.elasticsearch.path_parts");
 
   // Enum definitions
+  @Deprecated
   public static final class ErrorTypeValues {
     /**
      * A fallback error value to be used when the instrumentation doesn&#39;t define a custom value.
      */
-    public static final String OTHER = "_OTHER";
+    @Deprecated public static final String OTHER = "_OTHER";
 
     private ErrorTypeValues() {}
   }
 
+  @Deprecated
   public static final class FaasInvokedProviderValues {
     /** Alibaba Cloud. */
-    public static final String ALIBABA_CLOUD = "alibaba_cloud";
+    @Deprecated public static final String ALIBABA_CLOUD = "alibaba_cloud";
 
     /** Amazon Web Services. */
-    public static final String AWS = "aws";
+    @Deprecated public static final String AWS = "aws";
 
     /** Microsoft Azure. */
-    public static final String AZURE = "azure";
+    @Deprecated public static final String AZURE = "azure";
 
     /** Google Cloud Platform. */
-    public static final String GCP = "gcp";
+    @Deprecated public static final String GCP = "gcp";
 
     /** Tencent Cloud. */
-    public static final String TENCENT_CLOUD = "tencent_cloud";
+    @Deprecated public static final String TENCENT_CLOUD = "tencent_cloud";
 
     private FaasInvokedProviderValues() {}
   }
 
+  @Deprecated
   public static final class FaasTriggerValues {
     /** A response to some data source operation such as a database or filesystem read/write. */
-    public static final String DATASOURCE = "datasource";
+    @Deprecated public static final String DATASOURCE = "datasource";
 
     /** To provide an answer to an inbound HTTP request. */
-    public static final String HTTP = "http";
+    @Deprecated public static final String HTTP = "http";
 
     /** A function is set to be executed when messages are sent to a messaging system. */
-    public static final String PUBSUB = "pubsub";
+    @Deprecated public static final String PUBSUB = "pubsub";
 
     /** A function is scheduled to be executed regularly. */
-    public static final String TIMER = "timer";
+    @Deprecated public static final String TIMER = "timer";
 
     /** If none of the others apply. */
-    public static final String OTHER = "other";
+    @Deprecated public static final String OTHER = "other";
 
     private FaasTriggerValues() {}
   }
 
+  @Deprecated
   public static final class EventDomainValues {
     /** Events from browser apps. */
-    public static final String BROWSER = "browser";
+    @Deprecated public static final String BROWSER = "browser";
 
     /** Events from mobile apps. */
-    public static final String DEVICE = "device";
+    @Deprecated public static final String DEVICE = "device";
 
     /** Events from Kubernetes. */
-    public static final String K8S = "k8s";
+    @Deprecated public static final String K8S = "k8s";
 
     private EventDomainValues() {}
   }
 
+  @Deprecated
   public static final class LogIostreamValues {
     /** Logs from stdout stream. */
-    public static final String STDOUT = "stdout";
+    @Deprecated public static final String STDOUT = "stdout";
 
     /** Events from stderr stream. */
-    public static final String STDERR = "stderr";
+    @Deprecated public static final String STDERR = "stderr";
 
     private LogIostreamValues() {}
   }
 
+  @Deprecated
   public static final class IosStateValues {
     /**
      * The app has become `active`. Associated with UIKit notification `applicationDidBecomeActive`.
      */
-    public static final String ACTIVE = "active";
+    @Deprecated public static final String ACTIVE = "active";
 
     /**
      * The app is now `inactive`. Associated with UIKit notification `applicationWillResignActive`.
      */
-    public static final String INACTIVE = "inactive";
+    @Deprecated public static final String INACTIVE = "inactive";
 
     /**
      * The app is now in the background. This value is associated with UIKit notification
      * `applicationDidEnterBackground`.
      */
-    public static final String BACKGROUND = "background";
+    @Deprecated public static final String BACKGROUND = "background";
 
     /**
      * The app is now in the foreground. This value is associated with UIKit notification
      * `applicationWillEnterForeground`.
      */
-    public static final String FOREGROUND = "foreground";
+    @Deprecated public static final String FOREGROUND = "foreground";
 
     /**
      * The app is about to terminate. Associated with UIKit notification `applicationWillTerminate`.
      */
-    public static final String TERMINATE = "terminate";
+    @Deprecated public static final String TERMINATE = "terminate";
 
     private IosStateValues() {}
   }
 
+  @Deprecated
   public static final class AndroidStateValues {
     /**
      * Any time before Activity.onResume() or, if the app has no Activity, Context.startService()
      * has been called in the app for the first time.
      */
-    public static final String CREATED = "created";
+    @Deprecated public static final String CREATED = "created";
 
     /**
      * Any time after Activity.onPause() or, if the app has no Activity, Context.stopService() has
      * been called when the app was in the foreground state.
      */
-    public static final String BACKGROUND = "background";
+    @Deprecated public static final String BACKGROUND = "background";
 
     /**
      * Any time after Activity.onResume() or, if the app has no Activity, Context.startService() has
      * been called when the app was in either the created or background states.
      */
-    public static final String FOREGROUND = "foreground";
+    @Deprecated public static final String FOREGROUND = "foreground";
 
     private AndroidStateValues() {}
   }
 
+  @Deprecated
   public static final class StateValues {
     /** idle. */
-    public static final String IDLE = "idle";
+    @Deprecated public static final String IDLE = "idle";
 
     /** used. */
-    public static final String USED = "used";
+    @Deprecated public static final String USED = "used";
 
     private StateValues() {}
   }
 
+  @Deprecated
   public static final class JvmMemoryTypeValues {
     /** Heap memory. */
-    public static final String HEAP = "heap";
+    @Deprecated public static final String HEAP = "heap";
 
     /** Non-heap memory. */
-    public static final String NON_HEAP = "non_heap";
+    @Deprecated public static final String NON_HEAP = "non_heap";
 
     private JvmMemoryTypeValues() {}
   }
 
+  @Deprecated
   public static final class JvmThreadStateValues {
     /** A thread that has not yet started is in this state. */
-    public static final String NEW = "new";
+    @Deprecated public static final String NEW = "new";
 
     /** A thread executing in the Java virtual machine is in this state. */
-    public static final String RUNNABLE = "runnable";
+    @Deprecated public static final String RUNNABLE = "runnable";
 
     /** A thread that is blocked waiting for a monitor lock is in this state. */
-    public static final String BLOCKED = "blocked";
+    @Deprecated public static final String BLOCKED = "blocked";
 
     /**
      * A thread that is waiting indefinitely for another thread to perform a particular action is in
      * this state.
      */
-    public static final String WAITING = "waiting";
+    @Deprecated public static final String WAITING = "waiting";
 
     /**
      * A thread that is waiting for another thread to perform an action for up to a specified
      * waiting time is in this state.
      */
-    public static final String TIMED_WAITING = "timed_waiting";
+    @Deprecated public static final String TIMED_WAITING = "timed_waiting";
 
     /** A thread that has exited is in this state. */
-    public static final String TERMINATED = "terminated";
+    @Deprecated public static final String TERMINATED = "terminated";
 
     private JvmThreadStateValues() {}
   }
 
+  @Deprecated
   public static final class SystemCpuStateValues {
     /** user. */
-    public static final String USER = "user";
+    @Deprecated public static final String USER = "user";
 
     /** system. */
-    public static final String SYSTEM = "system";
+    @Deprecated public static final String SYSTEM = "system";
 
     /** nice. */
-    public static final String NICE = "nice";
+    @Deprecated public static final String NICE = "nice";
 
     /** idle. */
-    public static final String IDLE = "idle";
+    @Deprecated public static final String IDLE = "idle";
 
     /** iowait. */
-    public static final String IOWAIT = "iowait";
+    @Deprecated public static final String IOWAIT = "iowait";
 
     /** interrupt. */
-    public static final String INTERRUPT = "interrupt";
+    @Deprecated public static final String INTERRUPT = "interrupt";
 
     /** steal. */
-    public static final String STEAL = "steal";
+    @Deprecated public static final String STEAL = "steal";
 
     private SystemCpuStateValues() {}
   }
 
+  @Deprecated
   public static final class SystemMemoryStateValues {
     /** used. */
-    public static final String USED = "used";
+    @Deprecated public static final String USED = "used";
 
     /** free. */
-    public static final String FREE = "free";
+    @Deprecated public static final String FREE = "free";
 
     /** shared. */
-    public static final String SHARED = "shared";
+    @Deprecated public static final String SHARED = "shared";
 
     /** buffers. */
-    public static final String BUFFERS = "buffers";
+    @Deprecated public static final String BUFFERS = "buffers";
 
     /** cached. */
-    public static final String CACHED = "cached";
+    @Deprecated public static final String CACHED = "cached";
 
     /**
      * total.
@@ -2082,238 +2255,251 @@ public final class SemanticAttributes {
     private SystemMemoryStateValues() {}
   }
 
+  @Deprecated
   public static final class SystemPagingDirectionValues {
     /** in. */
-    public static final String IN = "in";
+    @Deprecated public static final String IN = "in";
 
     /** out. */
-    public static final String OUT = "out";
+    @Deprecated public static final String OUT = "out";
 
     private SystemPagingDirectionValues() {}
   }
 
+  @Deprecated
   public static final class SystemPagingStateValues {
     /** used. */
-    public static final String USED = "used";
+    @Deprecated public static final String USED = "used";
 
     /** free. */
-    public static final String FREE = "free";
+    @Deprecated public static final String FREE = "free";
 
     private SystemPagingStateValues() {}
   }
 
+  @Deprecated
   public static final class SystemPagingTypeValues {
     /** major. */
-    public static final String MAJOR = "major";
+    @Deprecated public static final String MAJOR = "major";
 
     /** minor. */
-    public static final String MINOR = "minor";
+    @Deprecated public static final String MINOR = "minor";
 
     private SystemPagingTypeValues() {}
   }
 
+  @Deprecated
   public static final class SystemDiskDirectionValues {
     /** read. */
-    public static final String READ = "read";
+    @Deprecated public static final String READ = "read";
 
     /** write. */
-    public static final String WRITE = "write";
+    @Deprecated public static final String WRITE = "write";
 
     private SystemDiskDirectionValues() {}
   }
 
+  @Deprecated
   public static final class SystemFilesystemStateValues {
     /** used. */
-    public static final String USED = "used";
+    @Deprecated public static final String USED = "used";
 
     /** free. */
-    public static final String FREE = "free";
+    @Deprecated public static final String FREE = "free";
 
     /** reserved. */
-    public static final String RESERVED = "reserved";
+    @Deprecated public static final String RESERVED = "reserved";
 
     private SystemFilesystemStateValues() {}
   }
 
+  @Deprecated
   public static final class SystemFilesystemTypeValues {
     /** fat32. */
-    public static final String FAT32 = "fat32";
+    @Deprecated public static final String FAT32 = "fat32";
 
     /** exfat. */
-    public static final String EXFAT = "exfat";
+    @Deprecated public static final String EXFAT = "exfat";
 
     /** ntfs. */
-    public static final String NTFS = "ntfs";
+    @Deprecated public static final String NTFS = "ntfs";
 
     /** refs. */
-    public static final String REFS = "refs";
+    @Deprecated public static final String REFS = "refs";
 
     /** hfsplus. */
-    public static final String HFSPLUS = "hfsplus";
+    @Deprecated public static final String HFSPLUS = "hfsplus";
 
     /** ext4. */
-    public static final String EXT4 = "ext4";
+    @Deprecated public static final String EXT4 = "ext4";
 
     private SystemFilesystemTypeValues() {}
   }
 
+  @Deprecated
   public static final class SystemNetworkDirectionValues {
     /** transmit. */
-    public static final String TRANSMIT = "transmit";
+    @Deprecated public static final String TRANSMIT = "transmit";
 
     /** receive. */
-    public static final String RECEIVE = "receive";
+    @Deprecated public static final String RECEIVE = "receive";
 
     private SystemNetworkDirectionValues() {}
   }
 
+  @Deprecated
   public static final class SystemNetworkStateValues {
     /** close. */
-    public static final String CLOSE = "close";
+    @Deprecated public static final String CLOSE = "close";
 
     /** close_wait. */
-    public static final String CLOSE_WAIT = "close_wait";
+    @Deprecated public static final String CLOSE_WAIT = "close_wait";
 
     /** closing. */
-    public static final String CLOSING = "closing";
+    @Deprecated public static final String CLOSING = "closing";
 
     /** delete. */
-    public static final String DELETE = "delete";
+    @Deprecated public static final String DELETE = "delete";
 
     /** established. */
-    public static final String ESTABLISHED = "established";
+    @Deprecated public static final String ESTABLISHED = "established";
 
     /** fin_wait_1. */
-    public static final String FIN_WAIT_1 = "fin_wait_1";
+    @Deprecated public static final String FIN_WAIT_1 = "fin_wait_1";
 
     /** fin_wait_2. */
-    public static final String FIN_WAIT_2 = "fin_wait_2";
+    @Deprecated public static final String FIN_WAIT_2 = "fin_wait_2";
 
     /** last_ack. */
-    public static final String LAST_ACK = "last_ack";
+    @Deprecated public static final String LAST_ACK = "last_ack";
 
     /** listen. */
-    public static final String LISTEN = "listen";
+    @Deprecated public static final String LISTEN = "listen";
 
     /** syn_recv. */
-    public static final String SYN_RECV = "syn_recv";
+    @Deprecated public static final String SYN_RECV = "syn_recv";
 
     /** syn_sent. */
-    public static final String SYN_SENT = "syn_sent";
+    @Deprecated public static final String SYN_SENT = "syn_sent";
 
     /** time_wait. */
-    public static final String TIME_WAIT = "time_wait";
+    @Deprecated public static final String TIME_WAIT = "time_wait";
 
     private SystemNetworkStateValues() {}
   }
 
+  @Deprecated
   public static final class SystemProcessesStatusValues {
     /** running. */
-    public static final String RUNNING = "running";
+    @Deprecated public static final String RUNNING = "running";
 
     /** sleeping. */
-    public static final String SLEEPING = "sleeping";
+    @Deprecated public static final String SLEEPING = "sleeping";
 
     /** stopped. */
-    public static final String STOPPED = "stopped";
+    @Deprecated public static final String STOPPED = "stopped";
 
     /** defunct. */
-    public static final String DEFUNCT = "defunct";
+    @Deprecated public static final String DEFUNCT = "defunct";
 
     private SystemProcessesStatusValues() {}
   }
 
+  @Deprecated
   public static final class NetSockFamilyValues {
     /** IPv4 address. */
-    public static final String INET = "inet";
+    @Deprecated public static final String INET = "inet";
 
     /** IPv6 address. */
-    public static final String INET6 = "inet6";
+    @Deprecated public static final String INET6 = "inet6";
 
     /** Unix domain socket path. */
-    public static final String UNIX = "unix";
+    @Deprecated public static final String UNIX = "unix";
 
     private NetSockFamilyValues() {}
   }
 
+  @Deprecated
   public static final class NetTransportValues {
     /** ip_tcp. */
-    public static final String IP_TCP = "ip_tcp";
+    @Deprecated public static final String IP_TCP = "ip_tcp";
 
     /** ip_udp. */
-    public static final String IP_UDP = "ip_udp";
+    @Deprecated public static final String IP_UDP = "ip_udp";
 
     /** Named or anonymous pipe. */
-    public static final String PIPE = "pipe";
+    @Deprecated public static final String PIPE = "pipe";
 
     /** In-process communication. */
-    public static final String INPROC = "inproc";
+    @Deprecated public static final String INPROC = "inproc";
 
     /** Something else (non IP-based). */
-    public static final String OTHER = "other";
+    @Deprecated public static final String OTHER = "other";
 
     private NetTransportValues() {}
   }
 
+  @Deprecated
   public static final class HttpRequestMethodValues {
     /** CONNECT method. */
-    public static final String CONNECT = "CONNECT";
+    @Deprecated public static final String CONNECT = "CONNECT";
 
     /** DELETE method. */
-    public static final String DELETE = "DELETE";
+    @Deprecated public static final String DELETE = "DELETE";
 
     /** GET method. */
-    public static final String GET = "GET";
+    @Deprecated public static final String GET = "GET";
 
     /** HEAD method. */
-    public static final String HEAD = "HEAD";
+    @Deprecated public static final String HEAD = "HEAD";
 
     /** OPTIONS method. */
-    public static final String OPTIONS = "OPTIONS";
+    @Deprecated public static final String OPTIONS = "OPTIONS";
 
     /** PATCH method. */
-    public static final String PATCH = "PATCH";
+    @Deprecated public static final String PATCH = "PATCH";
 
     /** POST method. */
-    public static final String POST = "POST";
+    @Deprecated public static final String POST = "POST";
 
     /** PUT method. */
-    public static final String PUT = "PUT";
+    @Deprecated public static final String PUT = "PUT";
 
     /** TRACE method. */
-    public static final String TRACE = "TRACE";
+    @Deprecated public static final String TRACE = "TRACE";
 
     /** Any HTTP method that the instrumentation has no prior knowledge of. */
-    public static final String OTHER = "_OTHER";
+    @Deprecated public static final String OTHER = "_OTHER";
 
     private HttpRequestMethodValues() {}
   }
 
+  @Deprecated
   public static final class MessagingOperationValues {
     /**
      * One or more messages are provided for publishing to an intermediary. If a single message is
      * published, the context of the &#34;Publish&#34; span can be used as the creation context and
      * no &#34;Create&#34; span needs to be created.
      */
-    public static final String PUBLISH = "publish";
+    @Deprecated public static final String PUBLISH = "publish";
 
     /**
      * A message is created. &#34;Create&#34; spans always refer to a single message and are used to
      * provide a unique creation context for messages in batch publishing scenarios.
      */
-    public static final String CREATE = "create";
+    @Deprecated public static final String CREATE = "create";
 
     /**
      * One or more messages are requested by a consumer. This operation refers to pull-based
      * scenarios, where consumers explicitly call methods of messaging SDKs to receive messages.
      */
-    public static final String RECEIVE = "receive";
+    @Deprecated public static final String RECEIVE = "receive";
 
     /**
      * One or more messages are passed to a consumer. This operation refers to push-based scenarios,
      * where consumer register callbacks which get called by messaging SDKs.
      */
-    public static final String DELIVER = "deliver";
+    @Deprecated public static final String DELIVER = "deliver";
 
     /**
      * process.
@@ -2325,581 +2511,599 @@ public final class SemanticAttributes {
     private MessagingOperationValues() {}
   }
 
+  @Deprecated
   public static final class MessagingRocketmqConsumptionModelValues {
     /** Clustering consumption model. */
-    public static final String CLUSTERING = "clustering";
+    @Deprecated public static final String CLUSTERING = "clustering";
 
     /** Broadcasting consumption model. */
-    public static final String BROADCASTING = "broadcasting";
+    @Deprecated public static final String BROADCASTING = "broadcasting";
 
     private MessagingRocketmqConsumptionModelValues() {}
   }
 
+  @Deprecated
   public static final class MessagingRocketmqMessageTypeValues {
     /** Normal message. */
-    public static final String NORMAL = "normal";
+    @Deprecated public static final String NORMAL = "normal";
 
     /** FIFO message. */
-    public static final String FIFO = "fifo";
+    @Deprecated public static final String FIFO = "fifo";
 
     /** Delay message. */
-    public static final String DELAY = "delay";
+    @Deprecated public static final String DELAY = "delay";
 
     /** Transaction message. */
-    public static final String TRANSACTION = "transaction";
+    @Deprecated public static final String TRANSACTION = "transaction";
 
     private MessagingRocketmqMessageTypeValues() {}
   }
 
+  @Deprecated
   public static final class NetworkConnectionSubtypeValues {
     /** GPRS. */
-    public static final String GPRS = "gprs";
+    @Deprecated public static final String GPRS = "gprs";
 
     /** EDGE. */
-    public static final String EDGE = "edge";
+    @Deprecated public static final String EDGE = "edge";
 
     /** UMTS. */
-    public static final String UMTS = "umts";
+    @Deprecated public static final String UMTS = "umts";
 
     /** CDMA. */
-    public static final String CDMA = "cdma";
+    @Deprecated public static final String CDMA = "cdma";
 
     /** EVDO Rel. 0. */
-    public static final String EVDO_0 = "evdo_0";
+    @Deprecated public static final String EVDO_0 = "evdo_0";
 
     /** EVDO Rev. A. */
-    public static final String EVDO_A = "evdo_a";
+    @Deprecated public static final String EVDO_A = "evdo_a";
 
     /** CDMA2000 1XRTT. */
-    public static final String CDMA2000_1XRTT = "cdma2000_1xrtt";
+    @Deprecated public static final String CDMA2000_1XRTT = "cdma2000_1xrtt";
 
     /** HSDPA. */
-    public static final String HSDPA = "hsdpa";
+    @Deprecated public static final String HSDPA = "hsdpa";
 
     /** HSUPA. */
-    public static final String HSUPA = "hsupa";
+    @Deprecated public static final String HSUPA = "hsupa";
 
     /** HSPA. */
-    public static final String HSPA = "hspa";
+    @Deprecated public static final String HSPA = "hspa";
 
     /** IDEN. */
-    public static final String IDEN = "iden";
+    @Deprecated public static final String IDEN = "iden";
 
     /** EVDO Rev. B. */
-    public static final String EVDO_B = "evdo_b";
+    @Deprecated public static final String EVDO_B = "evdo_b";
 
     /** LTE. */
-    public static final String LTE = "lte";
+    @Deprecated public static final String LTE = "lte";
 
     /** EHRPD. */
-    public static final String EHRPD = "ehrpd";
+    @Deprecated public static final String EHRPD = "ehrpd";
 
     /** HSPAP. */
-    public static final String HSPAP = "hspap";
+    @Deprecated public static final String HSPAP = "hspap";
 
     /** GSM. */
-    public static final String GSM = "gsm";
+    @Deprecated public static final String GSM = "gsm";
 
     /** TD-SCDMA. */
-    public static final String TD_SCDMA = "td_scdma";
+    @Deprecated public static final String TD_SCDMA = "td_scdma";
 
     /** IWLAN. */
-    public static final String IWLAN = "iwlan";
+    @Deprecated public static final String IWLAN = "iwlan";
 
     /** 5G NR (New Radio). */
-    public static final String NR = "nr";
+    @Deprecated public static final String NR = "nr";
 
     /** 5G NRNSA (New Radio Non-Standalone). */
-    public static final String NRNSA = "nrnsa";
+    @Deprecated public static final String NRNSA = "nrnsa";
 
     /** LTE CA. */
-    public static final String LTE_CA = "lte_ca";
+    @Deprecated public static final String LTE_CA = "lte_ca";
 
     private NetworkConnectionSubtypeValues() {}
   }
 
+  @Deprecated
   public static final class NetworkConnectionTypeValues {
     /** wifi. */
-    public static final String WIFI = "wifi";
+    @Deprecated public static final String WIFI = "wifi";
 
     /** wired. */
-    public static final String WIRED = "wired";
+    @Deprecated public static final String WIRED = "wired";
 
     /** cell. */
-    public static final String CELL = "cell";
+    @Deprecated public static final String CELL = "cell";
 
     /** unavailable. */
-    public static final String UNAVAILABLE = "unavailable";
+    @Deprecated public static final String UNAVAILABLE = "unavailable";
 
     /** unknown. */
-    public static final String UNKNOWN = "unknown";
+    @Deprecated public static final String UNKNOWN = "unknown";
 
     private NetworkConnectionTypeValues() {}
   }
 
+  @Deprecated
   public static final class NetworkTransportValues {
     /** TCP. */
-    public static final String TCP = "tcp";
+    @Deprecated public static final String TCP = "tcp";
 
     /** UDP. */
-    public static final String UDP = "udp";
+    @Deprecated public static final String UDP = "udp";
 
     /** Named or anonymous pipe. */
-    public static final String PIPE = "pipe";
+    @Deprecated public static final String PIPE = "pipe";
 
     /** Unix domain socket. */
-    public static final String UNIX = "unix";
+    @Deprecated public static final String UNIX = "unix";
 
     private NetworkTransportValues() {}
   }
 
+  @Deprecated
   public static final class NetworkTypeValues {
     /** IPv4. */
-    public static final String IPV4 = "ipv4";
+    @Deprecated public static final String IPV4 = "ipv4";
 
     /** IPv6. */
-    public static final String IPV6 = "ipv6";
+    @Deprecated public static final String IPV6 = "ipv6";
 
     private NetworkTypeValues() {}
   }
 
+  @Deprecated
   public static final class RpcConnectRpcErrorCodeValues {
     /** cancelled. */
-    public static final String CANCELLED = "cancelled";
+    @Deprecated public static final String CANCELLED = "cancelled";
 
     /** unknown. */
-    public static final String UNKNOWN = "unknown";
+    @Deprecated public static final String UNKNOWN = "unknown";
 
     /** invalid_argument. */
-    public static final String INVALID_ARGUMENT = "invalid_argument";
+    @Deprecated public static final String INVALID_ARGUMENT = "invalid_argument";
 
     /** deadline_exceeded. */
-    public static final String DEADLINE_EXCEEDED = "deadline_exceeded";
+    @Deprecated public static final String DEADLINE_EXCEEDED = "deadline_exceeded";
 
     /** not_found. */
-    public static final String NOT_FOUND = "not_found";
+    @Deprecated public static final String NOT_FOUND = "not_found";
 
     /** already_exists. */
-    public static final String ALREADY_EXISTS = "already_exists";
+    @Deprecated public static final String ALREADY_EXISTS = "already_exists";
 
     /** permission_denied. */
-    public static final String PERMISSION_DENIED = "permission_denied";
+    @Deprecated public static final String PERMISSION_DENIED = "permission_denied";
 
     /** resource_exhausted. */
-    public static final String RESOURCE_EXHAUSTED = "resource_exhausted";
+    @Deprecated public static final String RESOURCE_EXHAUSTED = "resource_exhausted";
 
     /** failed_precondition. */
-    public static final String FAILED_PRECONDITION = "failed_precondition";
+    @Deprecated public static final String FAILED_PRECONDITION = "failed_precondition";
 
     /** aborted. */
-    public static final String ABORTED = "aborted";
+    @Deprecated public static final String ABORTED = "aborted";
 
     /** out_of_range. */
-    public static final String OUT_OF_RANGE = "out_of_range";
+    @Deprecated public static final String OUT_OF_RANGE = "out_of_range";
 
     /** unimplemented. */
-    public static final String UNIMPLEMENTED = "unimplemented";
+    @Deprecated public static final String UNIMPLEMENTED = "unimplemented";
 
     /** internal. */
-    public static final String INTERNAL = "internal";
+    @Deprecated public static final String INTERNAL = "internal";
 
     /** unavailable. */
-    public static final String UNAVAILABLE = "unavailable";
+    @Deprecated public static final String UNAVAILABLE = "unavailable";
 
     /** data_loss. */
-    public static final String DATA_LOSS = "data_loss";
+    @Deprecated public static final String DATA_LOSS = "data_loss";
 
     /** unauthenticated. */
-    public static final String UNAUTHENTICATED = "unauthenticated";
+    @Deprecated public static final String UNAUTHENTICATED = "unauthenticated";
 
     private RpcConnectRpcErrorCodeValues() {}
   }
 
+  @Deprecated
   public static final class RpcGrpcStatusCodeValues {
     /** OK. */
-    public static final long OK = 0;
+    @Deprecated public static final long OK = 0;
 
     /** CANCELLED. */
-    public static final long CANCELLED = 1;
+    @Deprecated public static final long CANCELLED = 1;
 
     /** UNKNOWN. */
-    public static final long UNKNOWN = 2;
+    @Deprecated public static final long UNKNOWN = 2;
 
     /** INVALID_ARGUMENT. */
-    public static final long INVALID_ARGUMENT = 3;
+    @Deprecated public static final long INVALID_ARGUMENT = 3;
 
     /** DEADLINE_EXCEEDED. */
-    public static final long DEADLINE_EXCEEDED = 4;
+    @Deprecated public static final long DEADLINE_EXCEEDED = 4;
 
     /** NOT_FOUND. */
-    public static final long NOT_FOUND = 5;
+    @Deprecated public static final long NOT_FOUND = 5;
 
     /** ALREADY_EXISTS. */
-    public static final long ALREADY_EXISTS = 6;
+    @Deprecated public static final long ALREADY_EXISTS = 6;
 
     /** PERMISSION_DENIED. */
-    public static final long PERMISSION_DENIED = 7;
+    @Deprecated public static final long PERMISSION_DENIED = 7;
 
     /** RESOURCE_EXHAUSTED. */
-    public static final long RESOURCE_EXHAUSTED = 8;
+    @Deprecated public static final long RESOURCE_EXHAUSTED = 8;
 
     /** FAILED_PRECONDITION. */
-    public static final long FAILED_PRECONDITION = 9;
+    @Deprecated public static final long FAILED_PRECONDITION = 9;
 
     /** ABORTED. */
-    public static final long ABORTED = 10;
+    @Deprecated public static final long ABORTED = 10;
 
     /** OUT_OF_RANGE. */
-    public static final long OUT_OF_RANGE = 11;
+    @Deprecated public static final long OUT_OF_RANGE = 11;
 
     /** UNIMPLEMENTED. */
-    public static final long UNIMPLEMENTED = 12;
+    @Deprecated public static final long UNIMPLEMENTED = 12;
 
     /** INTERNAL. */
-    public static final long INTERNAL = 13;
+    @Deprecated public static final long INTERNAL = 13;
 
     /** UNAVAILABLE. */
-    public static final long UNAVAILABLE = 14;
+    @Deprecated public static final long UNAVAILABLE = 14;
 
     /** DATA_LOSS. */
-    public static final long DATA_LOSS = 15;
+    @Deprecated public static final long DATA_LOSS = 15;
 
     /** UNAUTHENTICATED. */
-    public static final long UNAUTHENTICATED = 16;
+    @Deprecated public static final long UNAUTHENTICATED = 16;
 
     private RpcGrpcStatusCodeValues() {}
   }
 
+  @Deprecated
   public static final class RpcSystemValues {
     /** gRPC. */
-    public static final String GRPC = "grpc";
+    @Deprecated public static final String GRPC = "grpc";
 
     /** Java RMI. */
-    public static final String JAVA_RMI = "java_rmi";
+    @Deprecated public static final String JAVA_RMI = "java_rmi";
 
     /** .NET WCF. */
-    public static final String DOTNET_WCF = "dotnet_wcf";
+    @Deprecated public static final String DOTNET_WCF = "dotnet_wcf";
 
     /** Apache Dubbo. */
-    public static final String APACHE_DUBBO = "apache_dubbo";
+    @Deprecated public static final String APACHE_DUBBO = "apache_dubbo";
 
     /** Connect RPC. */
-    public static final String CONNECT_RPC = "connect_rpc";
+    @Deprecated public static final String CONNECT_RPC = "connect_rpc";
 
     private RpcSystemValues() {}
   }
 
+  @Deprecated
   public static final class OpentracingRefTypeValues {
     /** The parent Span depends on the child Span in some capacity. */
-    public static final String CHILD_OF = "child_of";
+    @Deprecated public static final String CHILD_OF = "child_of";
 
     /** The parent Span doesn&#39;t depend in any way on the result of the child Span. */
-    public static final String FOLLOWS_FROM = "follows_from";
+    @Deprecated public static final String FOLLOWS_FROM = "follows_from";
 
     private OpentracingRefTypeValues() {}
   }
 
+  @Deprecated
   public static final class DbSystemValues {
     /** Some other SQL database. Fallback only. See notes. */
-    public static final String OTHER_SQL = "other_sql";
+    @Deprecated public static final String OTHER_SQL = "other_sql";
 
     /** Microsoft SQL Server. */
-    public static final String MSSQL = "mssql";
+    @Deprecated public static final String MSSQL = "mssql";
 
     /** Microsoft SQL Server Compact. */
-    public static final String MSSQLCOMPACT = "mssqlcompact";
+    @Deprecated public static final String MSSQLCOMPACT = "mssqlcompact";
 
     /** MySQL. */
-    public static final String MYSQL = "mysql";
+    @Deprecated public static final String MYSQL = "mysql";
 
     /** Oracle Database. */
-    public static final String ORACLE = "oracle";
+    @Deprecated public static final String ORACLE = "oracle";
 
     /** IBM Db2. */
-    public static final String DB2 = "db2";
+    @Deprecated public static final String DB2 = "db2";
 
     /** PostgreSQL. */
-    public static final String POSTGRESQL = "postgresql";
+    @Deprecated public static final String POSTGRESQL = "postgresql";
 
     /** Amazon Redshift. */
-    public static final String REDSHIFT = "redshift";
+    @Deprecated public static final String REDSHIFT = "redshift";
 
     /** Apache Hive. */
-    public static final String HIVE = "hive";
+    @Deprecated public static final String HIVE = "hive";
 
     /** Cloudscape. */
-    public static final String CLOUDSCAPE = "cloudscape";
+    @Deprecated public static final String CLOUDSCAPE = "cloudscape";
 
     /** HyperSQL DataBase. */
-    public static final String HSQLDB = "hsqldb";
+    @Deprecated public static final String HSQLDB = "hsqldb";
 
     /** Progress Database. */
-    public static final String PROGRESS = "progress";
+    @Deprecated public static final String PROGRESS = "progress";
 
     /** SAP MaxDB. */
-    public static final String MAXDB = "maxdb";
+    @Deprecated public static final String MAXDB = "maxdb";
 
     /** SAP HANA. */
-    public static final String HANADB = "hanadb";
+    @Deprecated public static final String HANADB = "hanadb";
 
     /** Ingres. */
-    public static final String INGRES = "ingres";
+    @Deprecated public static final String INGRES = "ingres";
 
     /** FirstSQL. */
-    public static final String FIRSTSQL = "firstsql";
+    @Deprecated public static final String FIRSTSQL = "firstsql";
 
     /** EnterpriseDB. */
-    public static final String EDB = "edb";
+    @Deprecated public static final String EDB = "edb";
 
     /** InterSystems Caché. */
-    public static final String CACHE = "cache";
+    @Deprecated public static final String CACHE = "cache";
 
     /** Adabas (Adaptable Database System). */
-    public static final String ADABAS = "adabas";
+    @Deprecated public static final String ADABAS = "adabas";
 
     /** Firebird. */
-    public static final String FIREBIRD = "firebird";
+    @Deprecated public static final String FIREBIRD = "firebird";
 
     /** Apache Derby. */
-    public static final String DERBY = "derby";
+    @Deprecated public static final String DERBY = "derby";
 
     /** FileMaker. */
-    public static final String FILEMAKER = "filemaker";
+    @Deprecated public static final String FILEMAKER = "filemaker";
 
     /** Informix. */
-    public static final String INFORMIX = "informix";
+    @Deprecated public static final String INFORMIX = "informix";
 
     /** InstantDB. */
-    public static final String INSTANTDB = "instantdb";
+    @Deprecated public static final String INSTANTDB = "instantdb";
 
     /** InterBase. */
-    public static final String INTERBASE = "interbase";
+    @Deprecated public static final String INTERBASE = "interbase";
 
     /** MariaDB. */
-    public static final String MARIADB = "mariadb";
+    @Deprecated public static final String MARIADB = "mariadb";
 
     /** Netezza. */
-    public static final String NETEZZA = "netezza";
+    @Deprecated public static final String NETEZZA = "netezza";
 
     /** Pervasive PSQL. */
-    public static final String PERVASIVE = "pervasive";
+    @Deprecated public static final String PERVASIVE = "pervasive";
 
     /** PointBase. */
-    public static final String POINTBASE = "pointbase";
+    @Deprecated public static final String POINTBASE = "pointbase";
 
     /** SQLite. */
-    public static final String SQLITE = "sqlite";
+    @Deprecated public static final String SQLITE = "sqlite";
 
     /** Sybase. */
-    public static final String SYBASE = "sybase";
+    @Deprecated public static final String SYBASE = "sybase";
 
     /** Teradata. */
-    public static final String TERADATA = "teradata";
+    @Deprecated public static final String TERADATA = "teradata";
 
     /** Vertica. */
-    public static final String VERTICA = "vertica";
+    @Deprecated public static final String VERTICA = "vertica";
 
     /** H2. */
-    public static final String H2 = "h2";
+    @Deprecated public static final String H2 = "h2";
 
     /** ColdFusion IMQ. */
-    public static final String COLDFUSION = "coldfusion";
+    @Deprecated public static final String COLDFUSION = "coldfusion";
 
     /** Apache Cassandra. */
-    public static final String CASSANDRA = "cassandra";
+    @Deprecated public static final String CASSANDRA = "cassandra";
 
     /** Apache HBase. */
-    public static final String HBASE = "hbase";
+    @Deprecated public static final String HBASE = "hbase";
 
     /** MongoDB. */
-    public static final String MONGODB = "mongodb";
+    @Deprecated public static final String MONGODB = "mongodb";
 
     /** Redis. */
-    public static final String REDIS = "redis";
+    @Deprecated public static final String REDIS = "redis";
 
     /** Couchbase. */
-    public static final String COUCHBASE = "couchbase";
+    @Deprecated public static final String COUCHBASE = "couchbase";
 
     /** CouchDB. */
-    public static final String COUCHDB = "couchdb";
+    @Deprecated public static final String COUCHDB = "couchdb";
 
     /** Microsoft Azure Cosmos DB. */
-    public static final String COSMOSDB = "cosmosdb";
+    @Deprecated public static final String COSMOSDB = "cosmosdb";
 
     /** Amazon DynamoDB. */
-    public static final String DYNAMODB = "dynamodb";
+    @Deprecated public static final String DYNAMODB = "dynamodb";
 
     /** Neo4j. */
-    public static final String NEO4J = "neo4j";
+    @Deprecated public static final String NEO4J = "neo4j";
 
     /** Apache Geode. */
-    public static final String GEODE = "geode";
+    @Deprecated public static final String GEODE = "geode";
 
     /** Elasticsearch. */
-    public static final String ELASTICSEARCH = "elasticsearch";
+    @Deprecated public static final String ELASTICSEARCH = "elasticsearch";
 
     /** Memcached. */
-    public static final String MEMCACHED = "memcached";
+    @Deprecated public static final String MEMCACHED = "memcached";
 
     /** CockroachDB. */
-    public static final String COCKROACHDB = "cockroachdb";
+    @Deprecated public static final String COCKROACHDB = "cockroachdb";
 
     /** OpenSearch. */
-    public static final String OPENSEARCH = "opensearch";
+    @Deprecated public static final String OPENSEARCH = "opensearch";
 
     /** ClickHouse. */
-    public static final String CLICKHOUSE = "clickhouse";
+    @Deprecated public static final String CLICKHOUSE = "clickhouse";
 
     /** Cloud Spanner. */
-    public static final String SPANNER = "spanner";
+    @Deprecated public static final String SPANNER = "spanner";
 
     /** Trino. */
-    public static final String TRINO = "trino";
+    @Deprecated public static final String TRINO = "trino";
 
     private DbSystemValues() {}
   }
 
+  @Deprecated
   public static final class DbCassandraConsistencyLevelValues {
     /** all. */
-    public static final String ALL = "all";
+    @Deprecated public static final String ALL = "all";
 
     /** each_quorum. */
-    public static final String EACH_QUORUM = "each_quorum";
+    @Deprecated public static final String EACH_QUORUM = "each_quorum";
 
     /** quorum. */
-    public static final String QUORUM = "quorum";
+    @Deprecated public static final String QUORUM = "quorum";
 
     /** local_quorum. */
-    public static final String LOCAL_QUORUM = "local_quorum";
+    @Deprecated public static final String LOCAL_QUORUM = "local_quorum";
 
     /** one. */
-    public static final String ONE = "one";
+    @Deprecated public static final String ONE = "one";
 
     /** two. */
-    public static final String TWO = "two";
+    @Deprecated public static final String TWO = "two";
 
     /** three. */
-    public static final String THREE = "three";
+    @Deprecated public static final String THREE = "three";
 
     /** local_one. */
-    public static final String LOCAL_ONE = "local_one";
+    @Deprecated public static final String LOCAL_ONE = "local_one";
 
     /** any. */
-    public static final String ANY = "any";
+    @Deprecated public static final String ANY = "any";
 
     /** serial. */
-    public static final String SERIAL = "serial";
+    @Deprecated public static final String SERIAL = "serial";
 
     /** local_serial. */
-    public static final String LOCAL_SERIAL = "local_serial";
+    @Deprecated public static final String LOCAL_SERIAL = "local_serial";
 
     private DbCassandraConsistencyLevelValues() {}
   }
 
+  @Deprecated
   public static final class DbCosmosdbConnectionModeValues {
     /** Gateway (HTTP) connections mode. */
-    public static final String GATEWAY = "gateway";
+    @Deprecated public static final String GATEWAY = "gateway";
 
     /** Direct connection. */
-    public static final String DIRECT = "direct";
+    @Deprecated public static final String DIRECT = "direct";
 
     private DbCosmosdbConnectionModeValues() {}
   }
 
+  @Deprecated
   public static final class DbCosmosdbOperationTypeValues {
     /** invalid. */
-    public static final String INVALID = "Invalid";
+    @Deprecated public static final String INVALID = "Invalid";
 
     /** create. */
-    public static final String CREATE = "Create";
+    @Deprecated public static final String CREATE = "Create";
 
     /** patch. */
-    public static final String PATCH = "Patch";
+    @Deprecated public static final String PATCH = "Patch";
 
     /** read. */
-    public static final String READ = "Read";
+    @Deprecated public static final String READ = "Read";
 
     /** read_feed. */
-    public static final String READ_FEED = "ReadFeed";
+    @Deprecated public static final String READ_FEED = "ReadFeed";
 
     /** delete. */
-    public static final String DELETE = "Delete";
+    @Deprecated public static final String DELETE = "Delete";
 
     /** replace. */
-    public static final String REPLACE = "Replace";
+    @Deprecated public static final String REPLACE = "Replace";
 
     /** execute. */
-    public static final String EXECUTE = "Execute";
+    @Deprecated public static final String EXECUTE = "Execute";
 
     /** query. */
-    public static final String QUERY = "Query";
+    @Deprecated public static final String QUERY = "Query";
 
     /** head. */
-    public static final String HEAD = "Head";
+    @Deprecated public static final String HEAD = "Head";
 
     /** head_feed. */
-    public static final String HEAD_FEED = "HeadFeed";
+    @Deprecated public static final String HEAD_FEED = "HeadFeed";
 
     /** upsert. */
-    public static final String UPSERT = "Upsert";
+    @Deprecated public static final String UPSERT = "Upsert";
 
     /** batch. */
-    public static final String BATCH = "Batch";
+    @Deprecated public static final String BATCH = "Batch";
 
     /** query_plan. */
-    public static final String QUERY_PLAN = "QueryPlan";
+    @Deprecated public static final String QUERY_PLAN = "QueryPlan";
 
     /** execute_javascript. */
-    public static final String EXECUTE_JAVASCRIPT = "ExecuteJavaScript";
+    @Deprecated public static final String EXECUTE_JAVASCRIPT = "ExecuteJavaScript";
 
     private DbCosmosdbOperationTypeValues() {}
   }
 
+  @Deprecated
   public static final class OtelStatusCodeValues {
     /**
      * The operation has been validated by an Application developer or Operator to have completed
      * successfully.
      */
-    public static final String OK = "OK";
+    @Deprecated public static final String OK = "OK";
 
     /** The operation contains an error. */
-    public static final String ERROR = "ERROR";
+    @Deprecated public static final String ERROR = "ERROR";
 
     private OtelStatusCodeValues() {}
   }
 
+  @Deprecated
   public static final class FaasDocumentOperationValues {
     /** When a new object is created. */
-    public static final String INSERT = "insert";
+    @Deprecated public static final String INSERT = "insert";
 
     /** When an object is modified. */
-    public static final String EDIT = "edit";
+    @Deprecated public static final String EDIT = "edit";
 
     /** When an object is deleted. */
-    public static final String DELETE = "delete";
+    @Deprecated public static final String DELETE = "delete";
 
     private FaasDocumentOperationValues() {}
   }
 
+  @Deprecated
   public static final class GraphqlOperationTypeValues {
     /** GraphQL query. */
-    public static final String QUERY = "query";
+    @Deprecated public static final String QUERY = "query";
 
     /** GraphQL mutation. */
-    public static final String MUTATION = "mutation";
+    @Deprecated public static final String MUTATION = "mutation";
 
     /** GraphQL subscription. */
-    public static final String SUBSCRIPTION = "subscription";
+    @Deprecated public static final String SUBSCRIPTION = "subscription";
 
     private GraphqlOperationTypeValues() {}
   }
 
+  @Deprecated
   public static final class MessageTypeValues {
     /** sent. */
-    public static final String SENT = "SENT";
+    @Deprecated public static final String SENT = "SENT";
 
     /** received. */
-    public static final String RECEIVED = "RECEIVED";
+    @Deprecated public static final String RECEIVED = "RECEIVED";
 
     private MessageTypeValues() {}
   }
@@ -2911,7 +3115,7 @@ public final class SemanticAttributes {
    * <p>Typically an event with that name should not be manually created. Instead {@link
    * io.opentelemetry.api.trace.Span#recordException(Throwable)} should be used.
    */
-  public static final String EXCEPTION_EVENT_NAME = "exception";
+  @Deprecated public static final String EXCEPTION_EVENT_NAME = "exception";
 
   /**
    * The name of the keyspace being accessed.
@@ -3161,22 +3365,22 @@ public final class SemanticAttributes {
   @Deprecated
   public static final class HttpFlavorValues {
     /** HTTP/1.0. */
-    public static final String HTTP_1_0 = "1.0";
+    @Deprecated public static final String HTTP_1_0 = "1.0";
 
     /** HTTP/1.1. */
-    public static final String HTTP_1_1 = "1.1";
+    @Deprecated public static final String HTTP_1_1 = "1.1";
 
     /** HTTP/2. */
-    public static final String HTTP_2_0 = "2.0";
+    @Deprecated public static final String HTTP_2_0 = "2.0";
 
     /** HTTP/3. */
-    public static final String HTTP_3_0 = "3.0";
+    @Deprecated public static final String HTTP_3_0 = "3.0";
 
     /** SPDY protocol. */
-    public static final String SPDY = "SPDY";
+    @Deprecated public static final String SPDY = "SPDY";
 
     /** QUIC protocol. */
-    public static final String QUIC = "QUIC";
+    @Deprecated public static final String QUIC = "QUIC";
 
     private HttpFlavorValues() {}
   }
@@ -3227,10 +3431,10 @@ public final class SemanticAttributes {
   @Deprecated
   public static final class MessagingDestinationKindValues {
     /** A message sent to a queue. */
-    public static final String QUEUE = "queue";
+    @Deprecated public static final String QUEUE = "queue";
 
     /** A message sent to a topic. */
-    public static final String TOPIC = "topic";
+    @Deprecated public static final String TOPIC = "topic";
 
     private MessagingDestinationKindValues() {}
   }
@@ -3252,10 +3456,10 @@ public final class SemanticAttributes {
   @Deprecated
   public static final class MessagingSourceKindValues {
     /** A message received from a queue. */
-    public static final String QUEUE = "queue";
+    @Deprecated public static final String QUEUE = "queue";
 
     /** A message received from a topic. */
-    public static final String TOPIC = "topic";
+    @Deprecated public static final String TOPIC = "topic";
 
     private MessagingSourceKindValues() {}
   }
@@ -3447,19 +3651,19 @@ public final class SemanticAttributes {
   @Deprecated
   public static final class NetHostConnectionTypeValues {
     /** wifi. */
-    public static final String WIFI = "wifi";
+    @Deprecated public static final String WIFI = "wifi";
 
     /** wired. */
-    public static final String WIRED = "wired";
+    @Deprecated public static final String WIRED = "wired";
 
     /** cell. */
-    public static final String CELL = "cell";
+    @Deprecated public static final String CELL = "cell";
 
     /** unavailable. */
-    public static final String UNAVAILABLE = "unavailable";
+    @Deprecated public static final String UNAVAILABLE = "unavailable";
 
     /** unknown. */
-    public static final String UNKNOWN = "unknown";
+    @Deprecated public static final String UNKNOWN = "unknown";
 
     private NetHostConnectionTypeValues() {}
   }
@@ -3473,67 +3677,67 @@ public final class SemanticAttributes {
   @Deprecated
   public static final class NetHostConnectionSubtypeValues {
     /** GPRS. */
-    public static final String GPRS = "gprs";
+    @Deprecated public static final String GPRS = "gprs";
 
     /** EDGE. */
-    public static final String EDGE = "edge";
+    @Deprecated public static final String EDGE = "edge";
 
     /** UMTS. */
-    public static final String UMTS = "umts";
+    @Deprecated public static final String UMTS = "umts";
 
     /** CDMA. */
-    public static final String CDMA = "cdma";
+    @Deprecated public static final String CDMA = "cdma";
 
     /** EVDO Rel. 0. */
-    public static final String EVDO_0 = "evdo_0";
+    @Deprecated public static final String EVDO_0 = "evdo_0";
 
     /** EVDO Rev. A. */
-    public static final String EVDO_A = "evdo_a";
+    @Deprecated public static final String EVDO_A = "evdo_a";
 
     /** CDMA2000 1XRTT. */
-    public static final String CDMA2000_1XRTT = "cdma2000_1xrtt";
+    @Deprecated public static final String CDMA2000_1XRTT = "cdma2000_1xrtt";
 
     /** HSDPA. */
-    public static final String HSDPA = "hsdpa";
+    @Deprecated public static final String HSDPA = "hsdpa";
 
     /** HSUPA. */
-    public static final String HSUPA = "hsupa";
+    @Deprecated public static final String HSUPA = "hsupa";
 
     /** HSPA. */
-    public static final String HSPA = "hspa";
+    @Deprecated public static final String HSPA = "hspa";
 
     /** IDEN. */
-    public static final String IDEN = "iden";
+    @Deprecated public static final String IDEN = "iden";
 
     /** EVDO Rev. B. */
-    public static final String EVDO_B = "evdo_b";
+    @Deprecated public static final String EVDO_B = "evdo_b";
 
     /** LTE. */
-    public static final String LTE = "lte";
+    @Deprecated public static final String LTE = "lte";
 
     /** EHRPD. */
-    public static final String EHRPD = "ehrpd";
+    @Deprecated public static final String EHRPD = "ehrpd";
 
     /** HSPAP. */
-    public static final String HSPAP = "hspap";
+    @Deprecated public static final String HSPAP = "hspap";
 
     /** GSM. */
-    public static final String GSM = "gsm";
+    @Deprecated public static final String GSM = "gsm";
 
     /** TD-SCDMA. */
-    public static final String TD_SCDMA = "td_scdma";
+    @Deprecated public static final String TD_SCDMA = "td_scdma";
 
     /** IWLAN. */
-    public static final String IWLAN = "iwlan";
+    @Deprecated public static final String IWLAN = "iwlan";
 
     /** 5G NR (New Radio). */
-    public static final String NR = "nr";
+    @Deprecated public static final String NR = "nr";
 
     /** 5G NRNSA (New Radio Non-Standalone). */
-    public static final String NRNSA = "nrnsa";
+    @Deprecated public static final String NRNSA = "nrnsa";
 
     /** LTE CA. */
-    public static final String LTE_CA = "lte_ca";
+    @Deprecated public static final String LTE_CA = "lte_ca";
 
     private NetHostConnectionSubtypeValues() {}
   }
@@ -3669,10 +3873,10 @@ public final class SemanticAttributes {
   @Deprecated
   public static final class TypeValues {
     /** Heap memory. */
-    public static final String HEAP = "heap";
+    @Deprecated public static final String HEAP = "heap";
 
     /** Non-heap memory. */
-    public static final String NON_HEAP = "non_heap";
+    @Deprecated public static final String NON_HEAP = "non_heap";
 
     private TypeValues() {}
   }

--- a/semconv/src/main/java/io/opentelemetry/semconv/ServiceAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/ServiceAttributes.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.semconv;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+// DO NOT EDIT, this is an Auto-generated file from
+// buildscripts/templates/SemanticAttributes.java.j2
+@SuppressWarnings("unused")
+public final class ServiceAttributes {
+
+  /**
+   * Logical name of the service.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>MUST be the same for all instances of horizontally scaled services. If the value was not
+   *       specified, SDKs MUST fallback to {@code unknown_service:} concatenated with <a
+   *       href="process.md#process">{@code process.executable.name}</a>, e.g. {@code
+   *       unknown_service:bash}. If {@code process.executable.name} is not available, the value
+   *       MUST be set to {@code unknown_service}.
+   * </ul>
+   */
+  public static final AttributeKey<String> SERVICE_NAME = stringKey("service.name");
+
+  /**
+   * The version string of the service API or implementation. The format is not defined by these
+   * conventions.
+   */
+  public static final AttributeKey<String> SERVICE_VERSION = stringKey("service.version");
+
+  private ServiceAttributes() {}
+}

--- a/semconv/src/main/java/io/opentelemetry/semconv/TelemetryAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/TelemetryAttributes.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.semconv.incubating;
+package io.opentelemetry.semconv;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
@@ -12,33 +12,9 @@ import io.opentelemetry.api.common.AttributeKey;
 // DO NOT EDIT, this is an Auto-generated file from
 // buildscripts/templates/SemanticAttributes.java.j2
 @SuppressWarnings("unused")
-public final class TelemetryIncubatingAttributes {
+public final class TelemetryAttributes {
 
-  /**
-   * The name of the auto instrumentation agent or distribution, if used.
-   *
-   * <p>Notes:
-   *
-   * <ul>
-   *   <li>Official auto instrumentation agents and distributions SHOULD set the {@code
-   *       telemetry.distro.name} attribute to a string starting with {@code opentelemetry-}, e.g.
-   *       {@code opentelemetry-java-instrumentation}.
-   * </ul>
-   */
-  public static final AttributeKey<String> TELEMETRY_DISTRO_NAME =
-      stringKey("telemetry.distro.name");
-
-  /** The version string of the auto instrumentation agent or distribution, if used. */
-  public static final AttributeKey<String> TELEMETRY_DISTRO_VERSION =
-      stringKey("telemetry.distro.version");
-
-  /**
-   * The language of the telemetry SDK.
-   *
-   * @deprecated deprecated in favor of stable {@link
-   *     io.opentelemetry.semconv.TelemetryAttributes#TELEMETRY_SDK_LANGUAGE} attribute.
-   */
-  @Deprecated
+  /** The language of the telemetry SDK. */
   public static final AttributeKey<String> TELEMETRY_SDK_LANGUAGE =
       stringKey("telemetry.sdk.language");
 
@@ -56,31 +32,15 @@ public final class TelemetryIncubatingAttributes {
    *       this case. All custom identifiers SHOULD be stable across different versions of an
    *       implementation.
    * </ul>
-   *
-   * @deprecated deprecated in favor of stable {@link
-   *     io.opentelemetry.semconv.TelemetryAttributes#TELEMETRY_SDK_NAME} attribute.
    */
-  @Deprecated
   public static final AttributeKey<String> TELEMETRY_SDK_NAME = stringKey("telemetry.sdk.name");
 
-  /**
-   * The version string of the telemetry SDK.
-   *
-   * @deprecated deprecated in favor of stable {@link
-   *     io.opentelemetry.semconv.TelemetryAttributes#TELEMETRY_SDK_VERSION} attribute.
-   */
-  @Deprecated
+  /** The version string of the telemetry SDK. */
   public static final AttributeKey<String> TELEMETRY_SDK_VERSION =
       stringKey("telemetry.sdk.version");
 
   // Enum definitions
-  /**
-   * Values for {@link #TELEMETRY_SDK_LANGUAGE}.
-   *
-   * @deprecated deprecated in favor of stable {@link
-   *     io.opentelemetry.semconv.TelemetryAttributes.TelemetrySdkLanguageValues} attribute.
-   */
-  @Deprecated
+  /** Values for {@link #TELEMETRY_SDK_LANGUAGE}. */
   public static final class TelemetrySdkLanguageValues {
     /** cpp. */
     public static final String CPP = "cpp";
@@ -121,5 +81,5 @@ public final class TelemetryIncubatingAttributes {
     private TelemetrySdkLanguageValues() {}
   }
 
-  private TelemetryIncubatingAttributes() {}
+  private TelemetryAttributes() {}
 }

--- a/semconv/src/main/java/io/opentelemetry/semconv/UrlAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/UrlAttributes.java
@@ -30,13 +30,22 @@ public final class UrlAttributes {
    *       form of {@code https://username:password@www.example.com/}. In such case username and
    *       password SHOULD be redacted and attribute's value SHOULD be {@code
    *       https://REDACTED:REDACTED@www.example.com/}. {@code url.full} SHOULD capture the absolute
-   *       URL when it is available (or can be reconstructed) and SHOULD NOT be validated or
-   *       modified except for sanitizing purposes.
+   *       URL when it is available (or can be reconstructed). Sensitive content provided in {@code
+   *       url.full} SHOULD be scrubbed when instrumentations can identify it.
    * </ul>
    */
   public static final AttributeKey<String> URL_FULL = stringKey("url.full");
 
-  /** The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.3">URI path</a> component */
+  /**
+   * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.3">URI path</a> component
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>Sensitive content provided in {@code url.path} SHOULD be scrubbed when instrumentations
+   *       can identify it.
+   * </ul>
+   */
   public static final AttributeKey<String> URL_PATH = stringKey("url.path");
 
   /**
@@ -45,8 +54,8 @@ public final class UrlAttributes {
    * <p>Notes:
    *
    * <ul>
-   *   <li>Sensitive content provided in query string SHOULD be scrubbed when instrumentations can
-   *       identify it.
+   *   <li>Sensitive content provided in {@code url.query} SHOULD be scrubbed when instrumentations
+   *       can identify it.
    * </ul>
    */
   public static final AttributeKey<String> URL_QUERY = stringKey("url.query");


### PR DESCRIPTION
The classes have almost been copied as-is with a few minor modifications:
- `@Deprecated` annotation to both classes and all their direct fields and inner classes
- add deprecation warning at class level